### PR TITLE
CryptoExchange.Net V12

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,8 @@ applyTo: "**/*"
 
 BitMEX.Net is a CryptoExchange.Net-based client for the BitMEX REST and websocket API. Use this file as the first source of truth when generating code for this repository.
 
+For multi-exchange code, use `CryptoExchange.Net.SharedApis` through the `.SharedClient` properties on the `ExchangeApi` surfaces. Use `.SharedClient.Discover()` to inspect supported shared features at runtime.
+
 ## Package And Client Shape
 
 - NuGet package id: `JKorf.BitMEX.Net`
@@ -192,7 +194,7 @@ Always check `subscription.Success` before using `subscription.Data`. Unsubscrib
 
 ## Result Handling
 
-REST calls return `HttpResult<T>` and socket subscriptions return `WebSocketResult<UpdateSubscription>`.
+REST calls return `HttpResult<T>` and socket subscriptions return `WebSocketResult<UpdateSubscription>`. Shared non-I/O symbol/cache helpers return `ExchangeCallResult<T>`.
 
 ```csharp
 var result = await client.ExchangeApi.ExchangeData.GetActiveSymbolsAsync();

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,7 +192,7 @@ Always check `subscription.Success` before using `subscription.Data`. Unsubscrib
 
 ## Result Handling
 
-REST calls return `WebCallResult<T>` and socket subscriptions return `CallResult<UpdateSubscription>`.
+REST calls return `HttpResult<T>` and socket subscriptions return `WebSocketResult<UpdateSubscription>`.
 
 ```csharp
 var result = await client.ExchangeApi.ExchangeData.GetActiveSymbolsAsync();

--- a/BitMEX.Net.UnitTests/BitMEXRestClientTests.cs
+++ b/BitMEX.Net.UnitTests/BitMEXRestClientTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using BitMEX.Net.Clients;
 using CryptoExchange.Net.Converters.SystemTextJson;
+using CryptoExchange.Net.Objects;
 
 namespace BitMEX.Net.UnitTests
 {
@@ -27,12 +28,11 @@ namespace BitMEX.Net.UnitTests
                     return headers["api-signature"].ToString();
                 },
                 "f03398fcf2c6e91f48d6b7f5e22de2d4996071613f0e76e130d5a381d5c894c5",
-                new Dictionary<string, object>
+                new Parameters(BitMEXExchange._parameterSerializationSettings)
                 {
                     { "symbol", "LTCBTC" },
                 },
                 DateTimeConverter.ParseFromDouble(1499827320559),
-                true,
                 false);
         }
 

--- a/BitMEX.Net.UnitTests/RestRequestTests.cs
+++ b/BitMEX.Net.UnitTests/RestRequestTests.cs
@@ -73,7 +73,7 @@ namespace BitMEX.Net.UnitTests
             await tester.ValidateAsync(client => client.ExchangeApi.Trading.GetPositionsAsync(), "GetPositions");
         }
 
-        private bool IsAuthenticated(WebCallResult result)
+        private bool IsAuthenticated(IHttpResult result)
         {
             return result.RequestHeaders.Any(x => x.Key == "api-signature");
         }

--- a/BitMEX.Net.UnitTests/SocketSubscriptionTests.cs
+++ b/BitMEX.Net.UnitTests/SocketSubscriptionTests.cs
@@ -28,7 +28,7 @@ namespace BitMEX.Net.UnitTests
                 OutputOriginalData = true
             }), logger);
 
-            var tester = new SocketSubscriptionValidator<BitMEXSocketClient>(client, "Subscriptions/Exchange", "wss://ws.bitmex.com/");
+            var tester = new SocketSubscriptionValidator<BitMEXSocketClient>(client, "Subscriptions/Exchange", "wss://ws.bitmex.com/realtime");
             await tester.ValidateConcurrentAsync<BitMEXAggTrade[]>(
                 (client, handler) => client.ExchangeApi.SubscribeToKlineUpdatesAsync("ETH_USDT", Enums.BinPeriod.OneDay, handler),
                 (client, handler) => client.ExchangeApi.SubscribeToKlineUpdatesAsync("ETH_USDT", Enums.BinPeriod.OneHour, handler),

--- a/BitMEX.Net/BitMEX.Net.csproj
+++ b/BitMEX.Net/BitMEX.Net.csproj
@@ -53,12 +53,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="CryptoExchange.Net" Version="12.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/BitMEX.Net/BitMEX.Net.csproj
+++ b/BitMEX.Net/BitMEX.Net.csproj
@@ -53,10 +53,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CryptoExchange.Net" Version="11.2.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/BitMEX.Net/BitMEXAuthenticationProvider.cs
+++ b/BitMEX.Net/BitMEXAuthenticationProvider.cs
@@ -27,7 +27,7 @@ namespace BitMEX.Net
             request.Headers.Add("api-expires", expires.Value.ToString());
             request.Headers.Add("api-key", Credential.Key);
 
-            var body = (request.BodyParameters == null || request.BodyParameters.Count == 0) ? "" : GetSerializedBody(_serializer, request.BodyParameters);
+            var body = (request.BodyParameters == null || request.BodyParameters.Empty) ? "" : GetSerializedBody(_serializer, request.BodyParameters);
             var queryParams = request.GetQueryString(true);
             if (!string.IsNullOrEmpty(queryParams))
                 queryParams = $"?{queryParams}";

--- a/BitMEX.Net/BitMEXAuthenticationProvider.cs
+++ b/BitMEX.Net/BitMEXAuthenticationProvider.cs
@@ -17,7 +17,7 @@ namespace BitMEX.Net
 
         public override void ProcessRequest(RestApiClient apiClient, RestRequestConfiguration request)
         {
-            if (!request.Authenticated)
+            if (!request.RequestDefinition.Authenticated)
                 return;
 
             var timestamp = GetTimestamp(apiClient);
@@ -32,7 +32,7 @@ namespace BitMEX.Net
             if (!string.IsNullOrEmpty(queryParams))
                 queryParams = $"?{queryParams}";
 
-            var signStr = $"{request.Method.ToString().ToUpperInvariant()}{request.Path}{queryParams}{expires}{body}";
+            var signStr = $"{request.RequestDefinition.Method.ToString().ToUpperInvariant()}{request.RequestDefinition.Path}{queryParams}{expires}{body}";
 
             request.Headers.Add("api-signature", SignHMACSHA256(signStr, SignOutputType.Hex));
 

--- a/BitMEX.Net/BitMEXExchange.cs
+++ b/BitMEX.Net/BitMEXExchange.cs
@@ -108,7 +108,7 @@ namespace BitMEX.Net
         /// <summary>
         /// Rate limiter configuration for the BitMEX API
         /// </summary>
-        public static BitMEXRateLimiters RateLimiter { get; } = new BitMEXRateLimiters();
+        public static BitMEXRateLimiters RateLimiter { get; set; } = new BitMEXRateLimiters();
     }
 
     /// <summary>
@@ -127,13 +127,19 @@ namespace BitMEX.Net
         public event Action<RateLimitUpdateEvent> RateLimitUpdated;
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        internal BitMEXRateLimiters()
+        /// <summary>
+        /// ctor
+        /// </summary>
+        public BitMEXRateLimiters()
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         {
             Initialize();
         }
 
-        private void Initialize()
+        /// <summary>
+        /// Initialize the rate limits
+        /// </summary>
+        protected virtual void Initialize()
         {
             BitMEX = new RateLimitGate("BitMEX")
                 .AddGuard(new RateLimitGuard(RateLimitGuard.PerHost, [], 120, TimeSpan.FromSeconds(60), RateLimitWindowType.Sliding));

--- a/BitMEX.Net/BitMEXExchange.cs
+++ b/BitMEX.Net/BitMEXExchange.cs
@@ -26,7 +26,8 @@ namespace BitMEX.Net
                 "https://www.bitmex.com",
                 ["https://www.bitmex.com/api/explorer/#/"],
                 PlatformType.CryptoCurrencyExchange,
-                CentralizationType.Centralized
+                CentralizationType.Centralized,
+                BitMEXEnvironment.All
                 );
 
         /// <summary>

--- a/BitMEX.Net/BitMEXExchange.cs
+++ b/BitMEX.Net/BitMEXExchange.cs
@@ -73,6 +73,12 @@ namespace BitMEX.Net
         };
 
         internal static JsonSerializerContext _serializerContext = JsonSerializerContextCache.GetOrCreate<BitMEXSourceGenerationContext>();
+        internal static ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings
+        {
+            Decimal = DecimalSerialization.Number,
+            DateTimes = DateTimeSerialization.Rfc3339String,
+            Bool = BoolSerialization.String
+        };
 
         /// <summary>
         /// Format a base and quote asset to an BitMEX recognized symbol 

--- a/BitMEX.Net/BitMEXUserDataTracker.cs
+++ b/BitMEX.Net/BitMEXUserDataTracker.cs
@@ -20,7 +20,6 @@ namespace BitMEX.Net
             SpotUserDataTrackerConfig? config) : base(
                 logger,
                 restClient.ExchangeApi.SharedClient,
-                null,
                 restClient.ExchangeApi.SharedClient,
                 socketClient.ExchangeApi.SharedClient,
                 restClient.ExchangeApi.SharedClient,
@@ -48,7 +47,6 @@ namespace BitMEX.Net
             string? userIdentifier,
             FuturesUserDataTrackerConfig? config) : base(logger,
                 restClient.ExchangeApi.SharedClient,
-                null,
                 restClient.ExchangeApi.SharedClient,
                 socketClient.ExchangeApi.SharedClient,
                 restClient.ExchangeApi.SharedClient,

--- a/BitMEX.Net/BitMEXUtils.cs
+++ b/BitMEX.Net/BitMEXUtils.cs
@@ -33,12 +33,12 @@ namespace BitMEX.Net
             try
             {
                 if (DateTime.UtcNow - _lastUpdateTime < TimeSpan.FromDays(1))
-                    return CallResult.SuccessResult;
+                    return CallResult.Ok();
 
                 var assets = await new BitMEXRestClient().ExchangeApi.ExchangeData.GetAssetsAsync(ct: ct).ConfigureAwait(false);
                 var symbols = await new BitMEXRestClient().ExchangeApi.ExchangeData.GetActiveSymbolsAsync(ct: ct).ConfigureAwait(false);
-                if (!assets || !symbols)
-                    return new CallResult(assets.Error ?? symbols.Error);
+                if (!assets.Success || !symbols.Success)
+                    return CallResult.Fail(assets.Error ?? symbols.Error!);
 
                 foreach (var asset in assets.Data)
                 {
@@ -54,7 +54,7 @@ namespace BitMEX.Net
                 }
 
                 _lastUpdateTime = DateTime.UtcNow;
-                return CallResult.SuccessResult;
+                return CallResult.Ok();
             }
             finally
             {

--- a/BitMEX.Net/Clients/BitMEXRestClient.cs
+++ b/BitMEX.Net/Clients/BitMEXRestClient.cs
@@ -45,7 +45,7 @@ namespace BitMEX.Net.Clients
         {
             Initialize(options.Value);
             
-            ExchangeApi = AddApiClient(new BitMEXRestClientExchangeApi(_logger, httpClient, options.Value));
+            ExchangeApi = AddApiClient(new BitMEXRestClientExchangeApi(loggerFactory, httpClient, options.Value));
         }
 
         #endregion

--- a/BitMEX.Net/Clients/BitMEXSocketClient.cs
+++ b/BitMEX.Net/Clients/BitMEXSocketClient.cs
@@ -45,10 +45,8 @@ namespace BitMEX.Net.Clients
         public BitMEXSocketClient(IOptions<BitMEXSocketOptions> options, ILoggerFactory? loggerFactory = null) : base(loggerFactory, "BitMEX")
         {
             Initialize(options.Value);
-
-            
-            ExchangeApi = AddApiClient(new BitMEXSocketClientExchangeApi(_logger, options.Value));
-
+                        
+            ExchangeApi = AddApiClient(new BitMEXSocketClientExchangeApi(loggerFactory, options.Value));
         }
         #endregion
 

--- a/BitMEX.Net/Clients/BitMEXUserClientProvider.cs
+++ b/BitMEX.Net/Clients/BitMEXUserClientProvider.cs
@@ -1,6 +1,7 @@
 ﻿using BitMEX.Net.Interfaces.Clients;
 using BitMEX.Net.Objects.Options;
 using CryptoExchange.Net.Authentication;
+using CryptoExchange.Net.Clients;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
@@ -10,18 +11,17 @@ using System.Net.Http;
 namespace BitMEX.Net.Clients
 {
     /// <inheritdoc />
-    public class BitMEXUserClientProvider : IBitMEXUserClientProvider
+    public class BitMEXUserClientProvider : UserClientProvider<
+        IBitMEXRestClient,
+        IBitMEXSocketClient,
+        BitMEXRestOptions,
+        BitMEXSocketOptions,
+        BitMEXCredentials,
+        BitMEXEnvironment
+        >, IBitMEXUserClientProvider
     {
-        private ConcurrentDictionary<string, IBitMEXRestClient> _restClients = new ConcurrentDictionary<string, IBitMEXRestClient>();
-        private ConcurrentDictionary<string, IBitMEXSocketClient> _socketClients = new ConcurrentDictionary<string, IBitMEXSocketClient>();
-
-        private readonly IOptions<BitMEXRestOptions> _restOptions;
-        private readonly IOptions<BitMEXSocketOptions> _socketOptions;
-        private readonly HttpClient _httpClient;
-        private readonly ILoggerFactory? _loggerFactory;
-
         /// <inheritdoc />
-        public string ExchangeName => BitMEXExchange.ExchangeName;
+        public override string ExchangeName => BitMEXExchange.ExchangeName;
 
         /// <summary>
         /// ctor
@@ -40,97 +40,15 @@ namespace BitMEX.Net.Clients
             ILoggerFactory? loggerFactory,
             IOptions<BitMEXRestOptions> restOptions,
             IOptions<BitMEXSocketOptions> socketOptions)
+            : base(httpClient, loggerFactory, restOptions, socketOptions)
         {
-            _httpClient = httpClient ?? new HttpClient();
-            _httpClient.Timeout = restOptions.Value.RequestTimeout;
-            _loggerFactory = loggerFactory;
-            _restOptions = restOptions;
-            _socketOptions = socketOptions;
         }
 
         /// <inheritdoc />
-        public void InitializeUserClient(string userIdentifier, BitMEXCredentials credentials, BitMEXEnvironment? environment = null)
-        {
-            CreateRestClient(userIdentifier, credentials, environment);
-            CreateSocketClient(userIdentifier, credentials, environment);
-        }
-
+        protected override IBitMEXRestClient ConstructRestClient(HttpClient client, ILoggerFactory? loggerFactory, IOptions<BitMEXRestOptions> options)
+            => new BitMEXRestClient(client, loggerFactory, options);
         /// <inheritdoc />
-        public void ClearUserClients(string userIdentifier)
-        {
-            _restClients.TryRemove(userIdentifier, out _);
-            _socketClients.TryRemove(userIdentifier, out _);
-        }
-
-        /// <inheritdoc />
-        public IBitMEXRestClient GetRestClient(string userIdentifier, BitMEXCredentials? credentials = null, BitMEXEnvironment? environment = null)
-        {
-            if (!_restClients.TryGetValue(userIdentifier, out var client) || client.Disposed)
-                client = CreateRestClient(userIdentifier, credentials, environment);
-
-            return client;
-        }
-
-        /// <inheritdoc />
-        public IBitMEXSocketClient GetSocketClient(string userIdentifier, BitMEXCredentials? credentials = null, BitMEXEnvironment? environment = null)
-        {
-            if (!_socketClients.TryGetValue(userIdentifier, out var client) || client.Disposed)
-                client = CreateSocketClient(userIdentifier, credentials, environment);
-
-            return client;
-        }
-
-        private IBitMEXRestClient CreateRestClient(string userIdentifier, BitMEXCredentials? credentials, BitMEXEnvironment? environment)
-        {
-            var clientRestOptions = SetRestEnvironment(environment);
-            var client = new BitMEXRestClient(_httpClient, _loggerFactory, clientRestOptions);
-            if (credentials != null)
-            {
-                client.SetApiCredentials(credentials);
-                _restClients[userIdentifier] = client;
-            }
-            return client;
-        }
-
-        private IBitMEXSocketClient CreateSocketClient(string userIdentifier, BitMEXCredentials? credentials, BitMEXEnvironment? environment)
-        {
-            var clientSocketOptions = SetSocketEnvironment(environment);
-            var client = new BitMEXSocketClient(clientSocketOptions!, _loggerFactory);
-            if (credentials != null)
-            {
-                client.SetApiCredentials(credentials);
-                _socketClients[userIdentifier] = client;
-            }
-            return client;
-        }
-
-        private IOptions<BitMEXRestOptions> SetRestEnvironment(BitMEXEnvironment? environment)
-        {
-            if (environment == null)
-                return _restOptions;
-
-            var newRestClientOptions = new BitMEXRestOptions();
-            var restOptions = _restOptions.Value.Set(newRestClientOptions);
-            newRestClientOptions.Environment = environment;
-            return Options.Create(newRestClientOptions);
-        }
-
-        private IOptions<BitMEXSocketOptions> SetSocketEnvironment(BitMEXEnvironment? environment)
-        {
-            if (environment == null)
-                return _socketOptions;
-
-            var newSocketClientOptions = new BitMEXSocketOptions();
-            var restOptions = _socketOptions.Value.Set(newSocketClientOptions);
-            newSocketClientOptions.Environment = environment;
-            return Options.Create(newSocketClientOptions);
-        }
-
-        private static T ApplyOptionsDelegate<T>(Action<T>? del) where T : new()
-        {
-            var opts = new T();
-            del?.Invoke(opts);
-            return opts;
-        }
+        protected override IBitMEXSocketClient ConstructSocketClient(ILoggerFactory? loggerFactory, IOptions<BitMEXSocketOptions> options)
+            => new BitMEXSocketClient(options, loggerFactory);
     }
 }

--- a/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApi.cs
+++ b/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApi.cs
@@ -44,12 +44,12 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #endregion
 
         #region constructor/destructor
-        internal BitMEXRestClientExchangeApi(ILogger logger, HttpClient? httpClient, BitMEXRestOptions options)
-            : base(logger, httpClient, options.Environment.RestClientAddress, options, options.ExchangeOptions)
+        internal BitMEXRestClientExchangeApi(ILoggerFactory? loggerFactory, HttpClient? httpClient, BitMEXRestOptions options)
+            : base(loggerFactory, BitMEXExchange.Metadata.Id, httpClient, options.Environment.RestClientAddress, options, options.ExchangeOptions)
         {
             Account = new BitMEXRestClientExchangeApiAccount(this);
-            ExchangeData = new BitMEXRestClientExchangeApiExchangeData(logger, this);
-            Trading = new BitMEXRestClientExchangeApiTrading(logger, this);
+            ExchangeData = new BitMEXRestClientExchangeApiExchangeData(_logger, this);
+            Trading = new BitMEXRestClientExchangeApiTrading(_logger, this);
         }
         #endregion
 
@@ -60,34 +60,23 @@ namespace BitMEX.Net.Clients.ExchangeApi
         protected override BitMEXAuthenticationProvider CreateAuthenticationProvider(BitMEXCredentials credentials)
             => new BitMEXAuthenticationProvider(credentials);
 
-        internal Task<WebCallResult> SendAsync(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
-            => SendToAddressAsync(BaseAddress, definition, parameters, cancellationToken, weight);
-
-        internal async Task<WebCallResult> SendToAddressAsync(string baseAddress, RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
+        internal async Task<HttpResult> SendAsync(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
         {
-            var result = await base.SendAsync(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
-            return result;
+            return await base.SendAsync<Unit>(definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
         }
 
-        internal Task<WebCallResult<T>> SendAsync<T>(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null) where T : class
-            => SendToAddressAsync<T>(BaseAddress, definition, parameters, cancellationToken, weight);
-
-        internal async Task<WebCallResult<T>> SendToAddressAsync<T>(string baseAddress, RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null) where T : class
+        internal async Task<HttpResult<T>> SendAsync<T>(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null) where T : class
         {
             if (parameters?.TryGetValue("filter", out var filter) == true)
                 parameters["filter"] = (_serializer ??= (IStringMessageSerializer)CreateSerializer()).Serialize(filter);
             if (parameters?.TryGetValue("columns", out var columns) == true)
                 parameters["columns"] = (_serializer ??= (IStringMessageSerializer)CreateSerializer()).Serialize(columns);
 
-            var result = await base.SendAsync<T>(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
-
-            // Optional response checking
-
-            return result;
+            return await base.SendAsync<T>(definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        protected override Task<WebCallResult<DateTime>> GetServerTimestampAsync()
+        protected override Task<HttpResult<DateTime>> GetServerTimestampAsync()
             => throw new NotImplementedException();
 
         /// <inheritdoc />

--- a/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiAccount.cs
+++ b/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiAccount.cs
@@ -24,14 +24,17 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get User Events
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXUserEvent[]>> GetUserEventsAsync(long? fromId = null, int? limit = null, CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXUserEvent[]>> GetUserEventsAsync(long? fromId = null, int? limit = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("startId", fromId);
-            parameters.AddOptional("count", limit);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/userEvent", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
+            parameters.Add("startId", fromId);
+            parameters.Add("count", limit);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/userEvent", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             var result = await _baseClient.SendAsync<BitMEXUserEventWrapper>(request, parameters, ct).ConfigureAwait(false);
-            return result.As<BitMEXUserEvent[]>(result.Data?.UserEvents);
+            if (!result.Success)
+                return HttpResult.Fail<BitMEXUserEvent[]>(result);
+
+            return HttpResult.Ok(result, result.Data.UserEvents);
         }
 
         #endregion
@@ -39,9 +42,9 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Account Info
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXAccountInfo>> GetAccountInfoAsync(CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXAccountInfo>> GetAccountInfoAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/user", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/user", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXAccountInfo>(request, null, ct).ConfigureAwait(false);
         }
 
@@ -50,9 +53,9 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Fees
 
         /// <inheritdoc />
-        public async Task<WebCallResult<Dictionary<string, BitMEXTradeFee>>> GetFeesAsync(CancellationToken ct = default) 
+        public async Task<HttpResult<Dictionary<string, BitMEXTradeFee>>> GetFeesAsync(CancellationToken ct = default) 
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/user/commission", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/user/commission", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<Dictionary<string, BitMEXTradeFee>>(request, null, ct).ConfigureAwait(false);
         }
 
@@ -61,12 +64,12 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Deposit Address
 
         /// <inheritdoc />
-        public async Task<WebCallResult<string>> GetDepositAddressAsync(string asset, string network, CancellationToken ct = default)
+        public async Task<HttpResult<string>> GetDepositAddressAsync(string asset, string network, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             parameters.Add("currency", asset);
             parameters.Add("network", network);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/user/depositAddress", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/user/depositAddress", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<string>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -76,9 +79,9 @@ namespace BitMEX.Net.Clients.ExchangeApi
 //        #region Get Transfer Accounts
 
 //        /// <inheritdoc />
-//        public async Task<WebCallResult<BitMEXTransaction[]>> GetTransferAccountsAsync(CancellationToken ct = default)
+//        public async Task<HttpResult<BitMEXTransaction[]>> GetTransferAccountsAsync(CancellationToken ct = default)
 //        {
-//            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/user/getWalletTransferAccounts", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+//            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/user/getWalletTransferAccounts", BitMEXExchange.RateLimiter.BitMEX, 1, true);
 //            return await _baseClient.SendAsync<BitMEXTransaction[]>(request, null, ct).ConfigureAwait(false);
 //        }
 
@@ -87,11 +90,11 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Margin Status
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXMarginStatus[]>> GetMarginStatusAsync(string? asset = null, CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXMarginStatus[]>> GetMarginStatusAsync(string? asset = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             parameters.Add("currency", asset ?? "all");
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/user/margin", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/user/margin", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             if (asset == null)
             {
                 return await _baseClient.SendAsync<BitMEXMarginStatus[]>(request, parameters, ct).ConfigureAwait(false);
@@ -99,7 +102,10 @@ namespace BitMEX.Net.Clients.ExchangeApi
             else
             {
                 var result = await _baseClient.SendAsync<BitMEXMarginStatus>(request, parameters, ct).ConfigureAwait(false);
-                return result.As<BitMEXMarginStatus[]>([result.Data]);
+                if (!result.Success)
+                    return HttpResult.Fail<BitMEXMarginStatus[]>(result);
+
+                return HttpResult.Ok(result, new[] { result.Data });
             }
         }
 
@@ -108,11 +114,11 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Quote Fill Ratio
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXFillRatio[]>> GetQuoteFillRatioAsync(long? accountId = null, CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXFillRatio[]>> GetQuoteFillRatioAsync(long? accountId = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             parameters.Add("targetAccountId", accountId?.ToString() ?? "*");
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/user/quoteFillRatio", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/user/quoteFillRatio", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXFillRatio[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -121,11 +127,11 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Quote Value Ratio
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXValueRatio[]>> GetQuoteValueRatioAsync(long accountId, CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXValueRatio[]>> GetQuoteValueRatioAsync(long accountId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             parameters.Add("targetAccountId", accountId);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/user/quoteValueRatio", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/user/quoteValueRatio", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXValueRatio[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -134,9 +140,9 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Trading Volume
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXUsdVolume[]>> GetTradingVolumeAsync(CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXUsdVolume[]>> GetTradingVolumeAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/user/tradingVolume", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/user/tradingVolume", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXUsdVolume[]>(request, null, ct).ConfigureAwait(false);
         }
 
@@ -145,11 +151,11 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Balances
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXBalance[]>> GetBalancesAsync(string? asset = null, CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXBalance[]>> GetBalancesAsync(string? asset = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             parameters.Add("currency", asset ?? "all");
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/user/wallet", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/user/wallet", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             if (asset == null)
             {
                 return await _baseClient.SendAsync<BitMEXBalance[]>(request, parameters, ct).ConfigureAwait(false);
@@ -157,7 +163,10 @@ namespace BitMEX.Net.Clients.ExchangeApi
             else
             {
                 var result = await _baseClient.SendAsync<BitMEXBalance>(request, parameters, ct).ConfigureAwait(false);
-                return result.As<BitMEXBalance[]>([result.Data]);
+                if (!result.Success)
+                    return HttpResult.Fail<BitMEXBalance[]>(result);
+
+                return HttpResult.Ok(result, new[] { result.Data } );
             }
         }
 
@@ -166,7 +175,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Balance History
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXTransaction[]>> GetBalanceHistoryAsync(
+        public async Task<HttpResult<BitMEXTransaction[]>> GetBalanceHistoryAsync(
             string? asset = null,
             long? targetAccountId = null,
             bool? reverse = null,
@@ -174,13 +183,13 @@ namespace BitMEX.Net.Clients.ExchangeApi
             int? limit = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             parameters.Add("currency", asset ?? "all");
-            parameters.AddOptional("targetAccountId", targetAccountId);
-            parameters.AddOptionalBoolString("reverse", reverse);
-            parameters.AddOptional("start", offset);
-            parameters.AddOptional("count", limit);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/user/walletHistory", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            parameters.Add("targetAccountId", targetAccountId);
+            parameters.Add("reverse", reverse);
+            parameters.Add("start", offset);
+            parameters.Add("count", limit);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/user/walletHistory", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXTransaction[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -189,13 +198,13 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Balance Summary
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXBalanceSummary[]>> GetBalanceSummaryAsync(string? asset = null, DateTime? startTime = null, DateTime? endTime = null, CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXBalanceSummary[]>> GetBalanceSummaryAsync(string? asset = null, DateTime? startTime = null, DateTime? endTime = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             parameters.Add("currency", asset ?? "all");
-            parameters.AddOptional("startTime", startTime?.ToRfc3339String());
-            parameters.AddOptional("endTime", endTime?.ToRfc3339String());
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/user/walletSummary", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            parameters.Add("startTime", startTime?.ToRfc3339String());
+            parameters.Add("endTime", endTime?.ToRfc3339String());
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/user/walletSummary", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXBalanceSummary[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -204,14 +213,14 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Transfer
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXTransaction>> TransferAsync(string asset, long fromAccountId, long toAccountId, long quantity, CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXTransaction>> TransferAsync(string asset, long fromAccountId, long toAccountId, long quantity, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             parameters.Add("currency", asset ?? "all");
             parameters.Add("fromAccountId", fromAccountId);
             parameters.Add("toAccountId", toAccountId);
             parameters.Add("amount", quantity);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v1/user/walletSummary", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v1/user/walletSummary", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXTransaction>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -220,7 +229,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Withdraw
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXTransaction>> WithdrawAsync(
+        public async Task<HttpResult<BitMEXTransaction>> WithdrawAsync(
             string asset,
             string network,
             long quantity,
@@ -233,18 +242,18 @@ namespace BitMEX.Net.Clients.ExchangeApi
             string? otpToken = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             parameters.Add("currency", asset);
             parameters.Add("network", network);
             parameters.Add("amount", quantity);
-            parameters.AddOptional("otpToken", otpToken);
-            parameters.AddOptional("address", address);
-            parameters.AddOptional("memo", memo);
-            parameters.AddOptional("addressId", addressId);
-            parameters.AddOptional("targetUserId", targetUserId);
-            parameters.AddOptionalString("fee", fee);
-            parameters.AddOptional("text", text);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v1/user/requestWithdrawal", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            parameters.Add("otpToken", otpToken);
+            parameters.Add("address", address);
+            parameters.Add("memo", memo);
+            parameters.Add("addressId", addressId);
+            parameters.Add("targetUserId", targetUserId);
+            parameters.Add("fee", fee);
+            parameters.Add("text", text);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v1/user/requestWithdrawal", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXTransaction>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -253,11 +262,11 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Cancel Withdrawal
 
         /// <inheritdoc />
-        public async Task<WebCallResult> CancelWithdrawalAsync(string transactId, CancellationToken ct = default)
+        public async Task<HttpResult> CancelWithdrawalAsync(string transactId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             parameters.Add("transactID", transactId);
-            var request = _definitions.GetOrCreate(HttpMethod.Delete, "api/v1/user/withdrawal", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Delete, _baseClient.BaseAddress, "api/v1/user/withdrawal", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -266,12 +275,12 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Set Isolated Margin
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXPosition>> SetIsolatedMarginAsync(string symbol, bool isolatedMarginEnabled, CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXPosition>> SetIsolatedMarginAsync(string symbol, bool isolatedMarginEnabled, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             parameters.Add("symbol", symbol);
-            parameters.AddBoolString("enabled", isolatedMarginEnabled);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v1/position/isolate", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            parameters.Add("enabled", isolatedMarginEnabled);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v1/position/isolate", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXPosition>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -280,13 +289,13 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Set Risk Limit
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXPosition>> SetRiskLimitAsync(string symbol, int riskLimit, long? targetAccountId = null, CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXPosition>> SetRiskLimitAsync(string symbol, int riskLimit, long? targetAccountId = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             parameters.Add("symbol", symbol);
             parameters.Add("riskLimit", riskLimit);
-            parameters.AddOptional("targetAccountId", targetAccountId);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v1/position/riskLimit", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            parameters.Add("targetAccountId", targetAccountId);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v1/position/riskLimit", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXPosition>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -295,13 +304,13 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Transfer Margin
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXPosition>> TransferMarginAsync(string symbol, long quantity, long? targetAccountId = null, CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXPosition>> TransferMarginAsync(string symbol, long quantity, long? targetAccountId = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             parameters.Add("symbol", symbol);
             parameters.Add("amount", quantity);
-            parameters.AddOptional("targetAccountId", targetAccountId);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v1/position/transferMargin", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            parameters.Add("targetAccountId", targetAccountId);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v1/position/transferMargin", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXPosition>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -310,10 +319,10 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Saved Addresses
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXAddress[]>> GetSavedAddressesAsync(CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXAddress[]>> GetSavedAddressesAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/address", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/address", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXAddress[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -322,7 +331,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Add Saved Addresses
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXAddress>> AddSavedAddressAsync(
+        public async Task<HttpResult<BitMEXAddress>> AddSavedAddressAsync(
             string currency,
             string network,
             string address,
@@ -334,17 +343,17 @@ namespace BitMEX.Net.Clients.ExchangeApi
             string? otpToken = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             parameters.Add("currency", currency);
             parameters.Add("network", network);
             parameters.Add("address", address);
             parameters.Add("name", name);
-            parameters.AddOptional("note", note);
-            parameters.AddOptional("skipConfirm", skipConfirm);
-            parameters.AddOptional("skip2FA", skip2FA);
-            parameters.AddOptional("memo", memo);
-            parameters.AddOptional("otpToken", otpToken);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v1/address", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            parameters.Add("note", note);
+            parameters.Add("skipConfirm", skipConfirm);
+            parameters.Add("skip2FA", skip2FA);
+            parameters.Add("memo", memo);
+            parameters.Add("otpToken", otpToken);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v1/address", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXAddress>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -353,10 +362,10 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Address Book Settings
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXAddressBookConfig>> GetAddressBookSettingsAsync(CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXAddressBookConfig>> GetAddressBookSettingsAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/addressConfig", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/addressConfig", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXAddressBookConfig>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -365,10 +374,10 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Api Key Info
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXApiKey[]>> GetApiKeyInfoAsync(CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXApiKey[]>> GetApiKeyInfoAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/apiKey", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/apiKey", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXApiKey[]>(request, parameters, ct).ConfigureAwait(false);
         }
 

--- a/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiExchangeData.cs
+++ b/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiExchangeData.cs
@@ -29,11 +29,14 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Server Time
 
         /// <inheritdoc />
-        public async Task<WebCallResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default)
+        public async Task<HttpResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1", BitMEXExchange.RateLimiter.BitMEX, 1, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1", BitMEXExchange.RateLimiter.BitMEX, 1, false);
             var result = await _baseClient.SendAsync<BitMEXServerTime>(request, null, ct).ConfigureAwait(false);
-            return result.As(result.Data?.Timestamp ?? default);
+            if (!result.Success)
+                return HttpResult.Fail<DateTime>(result);
+
+            return HttpResult.Ok(result, result.Data.Timestamp);
         }
 
         #endregion
@@ -41,9 +44,9 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Active Symbols
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXSymbol[]>> GetActiveSymbolsAsync(CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXSymbol[]>> GetActiveSymbolsAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/instrument/active", BitMEXExchange.RateLimiter.BitMEX, 1, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/instrument/active", BitMEXExchange.RateLimiter.BitMEX, 1, false);
             return await _baseClient.SendAsync<BitMEXSymbol[]>(request, null, ct).ConfigureAwait(false);
         }
 
@@ -52,7 +55,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get All Symbols
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXSymbol[]>> GetSymbolsAsync(
+        public async Task<HttpResult<BitMEXSymbol[]>> GetSymbolsAsync(
             string? symbol = null,
             SymbolFilter? symbolFilter = null,
             Dictionary<string, object>? filter = null,
@@ -64,17 +67,17 @@ namespace BitMEX.Net.Clients.ExchangeApi
             int? limit = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             if (symbol != null)
-                parameters.AddOptional("symbol", symbol + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
-            parameters.AddOptional("filter", filter);
-            parameters.AddOptional("columns", columns);
-            parameters.AddOptional("count", limit);
-            parameters.AddOptional("start", offset);
-            parameters.AddOptionalBoolString("reverse", reverse);
-            parameters.AddOptional("startTime", startTime?.ToRfc3339String());
-            parameters.AddOptional("endTime", endTime?.ToRfc3339String());
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/instrument", BitMEXExchange.RateLimiter.BitMEX, 1, false);
+                parameters.Add("symbol", symbol + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
+            parameters.AddRaw("filter", filter);
+            parameters.AddArray("columns", columns);
+            parameters.Add("count", limit);
+            parameters.Add("start", offset);
+            parameters.Add("reverse", reverse);
+            parameters.Add("startTime", startTime?.ToRfc3339String());
+            parameters.Add("endTime", endTime?.ToRfc3339String());
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/instrument", BitMEXExchange.RateLimiter.BitMEX, 1, false);
             return await _baseClient.SendAsync<BitMEXSymbol[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -83,9 +86,9 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Active Intervals
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXIntervals>> GetActiveIntervalsAsync(CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXIntervals>> GetActiveIntervalsAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/instrument/activeIntervals", BitMEXExchange.RateLimiter.BitMEX, 1, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/instrument/activeIntervals", BitMEXExchange.RateLimiter.BitMEX, 1, false);
             return await _baseClient.SendAsync<BitMEXIntervals>(request, null, ct).ConfigureAwait(false);
         }
 
@@ -94,7 +97,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Composite Indexes
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXCompositeIndex[]>> GetCompositeIndexesAsync(
+        public async Task<HttpResult<BitMEXCompositeIndex[]>> GetCompositeIndexesAsync(
             string symbol,
             Dictionary<string, object>? filter = null,
             IEnumerable<string>? columns = null,
@@ -105,17 +108,17 @@ namespace BitMEX.Net.Clients.ExchangeApi
             int? limit = null, 
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             parameters.Add("symbol", symbol);
-            parameters.AddOptional("filter", filter);
-            parameters.AddOptional("columns", columns);
-            parameters.AddOptional("count", limit);
-            parameters.AddOptional("start", offset);
-            parameters.AddOptionalBoolString("reverse", reverse);
-            parameters.AddOptional("startTime", startTime?.ToRfc3339String());
-            parameters.AddOptional("endTime", endTime?.ToRfc3339String());
+            parameters.AddRaw("filter", filter);
+            parameters.AddArray("columns", columns);
+            parameters.Add("count", limit);
+            parameters.Add("start", offset);
+            parameters.Add("reverse", reverse);
+            parameters.Add("startTime", startTime?.ToRfc3339String());
+            parameters.Add("endTime", endTime?.ToRfc3339String());
 
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/instrument/compositeIndex", BitMEXExchange.RateLimiter.BitMEX, 1, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/instrument/compositeIndex", BitMEXExchange.RateLimiter.BitMEX, 1, false);
             return await _baseClient.SendAsync<BitMEXCompositeIndex[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -124,9 +127,9 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Indices
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXIndex[]>> GetIndicesAsync(CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXIndex[]>> GetIndicesAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/instrument/indices", BitMEXExchange.RateLimiter.BitMEX, 1, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/instrument/indices", BitMEXExchange.RateLimiter.BitMEX, 1, false);
             return await _baseClient.SendAsync<BitMEXIndex[]>(request, null, ct).ConfigureAwait(false);
         }
 
@@ -135,9 +138,9 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Symbol Volumes
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXSymbolVolume[]>> GetSymbolVolumesAsync(CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXSymbolVolume[]>> GetSymbolVolumesAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/instrument/usdVolume", BitMEXExchange.RateLimiter.BitMEX, 1, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/instrument/usdVolume", BitMEXExchange.RateLimiter.BitMEX, 1, false);
             return await _baseClient.SendAsync<BitMEXSymbolVolume[]>(request, null, ct).ConfigureAwait(false);
         }
 
@@ -146,7 +149,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Trades
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXTrade[]>> GetTradesAsync(
+        public async Task<HttpResult<BitMEXTrade[]>> GetTradesAsync(
             string symbol,
             SymbolFilter? symbolFilter = null,
             Dictionary<string, object>? filter = null,
@@ -158,18 +161,18 @@ namespace BitMEX.Net.Clients.ExchangeApi
             int? limit = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             if (symbol != null)
-                parameters.AddOptional("symbol", symbol + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
-            parameters.AddOptional("filter", filter);
-            parameters.AddOptional("columns", columns);
-            parameters.AddOptional("count", limit);
-            parameters.AddBoolString("reverse", reverse ?? true);
-            parameters.AddOptional("startTime", startTime?.ToRfc3339String());
-            parameters.AddOptional("endTime", endTime?.ToRfc3339String());
-            parameters.AddOptional("start", offset);
+                parameters.Add("symbol", symbol + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
+            parameters.AddRaw("filter", filter);
+            parameters.AddArray("columns", columns);
+            parameters.Add("count", limit);
+            parameters.Add("reverse", reverse ?? true);
+            parameters.Add("startTime", startTime?.ToRfc3339String());
+            parameters.Add("endTime", endTime?.ToRfc3339String());
+            parameters.Add("start", offset);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/trade", BitMEXExchange.RateLimiter.BitMEX, 1, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/trade", BitMEXExchange.RateLimiter.BitMEX, 1, false);
             return await _baseClient.SendAsync<BitMEXTrade[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -178,7 +181,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Klines
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXAggTrade[]>> GetKlinesAsync(
+        public async Task<HttpResult<BitMEXAggTrade[]>> GetKlinesAsync(
             string symbol,
             BinPeriod period,
             SymbolFilter? symbolFilter = null,
@@ -192,20 +195,20 @@ namespace BitMEX.Net.Clients.ExchangeApi
             int? limit = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             if (symbol != null)
-                parameters.AddOptional("symbol", symbol + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
-            parameters.AddEnum("binSize", period);
-            parameters.AddOptional("partial", partial);
-            parameters.AddOptional("filter", filter);
-            parameters.AddOptional("columns", columns);
-            parameters.AddOptional("count", limit);
-            parameters.AddOptional("start", offset);
-            parameters.AddBoolString("reverse", reverse ?? true);
-            parameters.AddOptional("startTime", startTime?.ToRfc3339String());
-            parameters.AddOptional("endTime", endTime?.ToRfc3339String());
+                parameters.Add("symbol", symbol + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
+            parameters.Add("binSize", period);
+            parameters.Add("partial", partial);
+            parameters.AddRaw("filter", filter);
+            parameters.AddArray("columns", columns);
+            parameters.Add("count", limit);
+            parameters.Add("start", offset);
+            parameters.Add("reverse", reverse ?? true);
+            parameters.Add("startTime", startTime?.ToRfc3339String());
+            parameters.Add("endTime", endTime?.ToRfc3339String());
 
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/trade/bucketed", BitMEXExchange.RateLimiter.BitMEX, 1, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/trade/bucketed", BitMEXExchange.RateLimiter.BitMEX, 1, false);
             return await _baseClient.SendAsync<BitMEXAggTrade[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -214,10 +217,10 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Exchange Stats
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXExchangeStat[]>> GetExchangeStatsAsync(CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXExchangeStat[]>> GetExchangeStatsAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/stats", BitMEXExchange.RateLimiter.BitMEX, 1, false);
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/stats", BitMEXExchange.RateLimiter.BitMEX, 1, false);
             return await _baseClient.SendAsync<BitMEXExchangeStat[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -226,10 +229,10 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Exchange Stat History
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXExchangeStatHistory[]>> GetExchangeStatHistoryAsync(CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXExchangeStatHistory[]>> GetExchangeStatHistoryAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/stats/history", BitMEXExchange.RateLimiter.BitMEX, 1, false);
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/stats/history", BitMEXExchange.RateLimiter.BitMEX, 1, false);
             return await _baseClient.SendAsync<BitMEXExchangeStatHistory[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -238,10 +241,10 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Exchange Stat History USD
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXExchangeStatHistoryUsd[]>> GetExchangeStatHistoryUSDAsync(CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXExchangeStatHistoryUsd[]>> GetExchangeStatHistoryUSDAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/stats/historyUSD", BitMEXExchange.RateLimiter.BitMEX, 1, false);
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/stats/historyUSD", BitMEXExchange.RateLimiter.BitMEX, 1, false);
             return await _baseClient.SendAsync<BitMEXExchangeStatHistoryUsd[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -250,7 +253,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Settlement History
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXSettlementHistory[]>> GetSettlementHistoryAsync(
+        public async Task<HttpResult<BitMEXSettlementHistory[]>> GetSettlementHistoryAsync(
             string symbol,
             SymbolFilter? symbolFilter = null,
             Dictionary<string, object>? filter = null,
@@ -262,17 +265,17 @@ namespace BitMEX.Net.Clients.ExchangeApi
             int? limit = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             if (symbol != null)
-                parameters.AddOptional("symbol", symbol + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
-            parameters.AddOptional("filter", filter);
-            parameters.AddOptional("columns", columns);
-            parameters.AddOptional("count", limit);
-            parameters.AddOptional("start", offset);
-            parameters.AddBoolString("reverse", reverse ?? true);
-            parameters.AddOptional("startTime", startTime?.ToRfc3339String());
-            parameters.AddOptional("endTime", endTime?.ToRfc3339String());
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/settlement", BitMEXExchange.RateLimiter.BitMEX, 1, false);
+                parameters.Add("symbol", symbol + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
+            parameters.AddRaw("filter", filter);
+            parameters.AddArray("columns", columns);
+            parameters.Add("count", limit);
+            parameters.Add("start", offset);
+            parameters.Add("reverse", reverse ?? true);
+            parameters.Add("startTime", startTime?.ToRfc3339String());
+            parameters.Add("endTime", endTime?.ToRfc3339String());
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/settlement", BitMEXExchange.RateLimiter.BitMEX, 1, false);
             return await _baseClient.SendAsync<BitMEXSettlementHistory[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -281,7 +284,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Book Ticker History
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXBookTicker[]>> GetBookTickerHistoryAsync(
+        public async Task<HttpResult<BitMEXBookTicker[]>> GetBookTickerHistoryAsync(
             string symbol,
             SymbolFilter? symbolFilter = null,
             Dictionary<string, object>? filter = null,
@@ -293,17 +296,17 @@ namespace BitMEX.Net.Clients.ExchangeApi
             int? limit = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             if (symbol != null)
-                parameters.AddOptional("symbol", symbol + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
-            parameters.AddOptional("filter", filter);
-            parameters.AddOptional("columns", columns);
-            parameters.AddOptional("count", limit);
-            parameters.AddOptional("start", offset);
-            parameters.AddBoolString("reverse", reverse ?? true);
-            parameters.AddOptional("startTime", startTime?.ToRfc3339String());
-            parameters.AddOptional("endTime", endTime?.ToRfc3339String());
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/quote", BitMEXExchange.RateLimiter.BitMEX, 1, false);
+                parameters.Add("symbol", symbol + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
+            parameters.AddRaw("filter", filter);
+            parameters.AddArray("columns", columns);
+            parameters.Add("count", limit);
+            parameters.Add("start", offset);
+            parameters.Add("reverse", reverse ?? true);
+            parameters.Add("startTime", startTime?.ToRfc3339String());
+            parameters.Add("endTime", endTime?.ToRfc3339String());
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/quote", BitMEXExchange.RateLimiter.BitMEX, 1, false);
             return await _baseClient.SendAsync<BitMEXBookTicker[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -312,7 +315,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Aggregated Book Ticker
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXBookTicker[]>> GetAggregatedBookTickerHistoryAsync(
+        public async Task<HttpResult<BitMEXBookTicker[]>> GetAggregatedBookTickerHistoryAsync(
             string symbol,
             BinPeriod period,
             SymbolFilter? symbolFilter = null,
@@ -326,19 +329,19 @@ namespace BitMEX.Net.Clients.ExchangeApi
             int? limit = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             if (symbol != null)
-                parameters.AddOptional("symbol", symbol + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
-            parameters.AddEnum("binSize", period);
-            parameters.AddOptional("partial", partial);
-            parameters.AddOptional("filter", filter);
-            parameters.AddOptional("columns", columns);
-            parameters.AddOptional("count", limit);
-            parameters.AddOptional("start", offset);
-            parameters.AddBoolString("reverse", reverse ?? true);
-            parameters.AddOptional("startTime", startTime?.ToRfc3339String());
-            parameters.AddOptional("endTime", endTime?.ToRfc3339String());
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/quote/bucketed", BitMEXExchange.RateLimiter.BitMEX, 1, false);
+                parameters.Add("symbol", symbol + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
+            parameters.Add("binSize", period);
+            parameters.Add("partial", partial);
+            parameters.AddRaw("filter", filter);
+            parameters.AddArray("columns", columns);
+            parameters.Add("count", limit);
+            parameters.Add("start", offset);
+            parameters.Add("reverse", reverse ?? true);
+            parameters.Add("startTime", startTime?.ToRfc3339String());
+            parameters.Add("endTime", endTime?.ToRfc3339String());
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/quote/bucketed", BitMEXExchange.RateLimiter.BitMEX, 1, false);
             return await _baseClient.SendAsync<BitMEXBookTicker[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -347,15 +350,15 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Order Book
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXOrderBook>> GetOrderBookAsync(string symbol, int limit, CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXOrderBook>> GetOrderBookAsync(string symbol, int limit, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             parameters.Add("symbol", symbol);
             parameters.Add("depth", limit);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/orderBook/L2", BitMEXExchange.RateLimiter.BitMEX, 1, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/orderBook/L2", BitMEXExchange.RateLimiter.BitMEX, 1, false);
             var result = await _baseClient.SendAsync<BitMEXOrderBookEntry[]>(request, parameters, ct).ConfigureAwait(false);
-            if (!result)
-                return result.As<BitMEXOrderBook>(default);
+            if (!result.Success)
+                return HttpResult.Fail<BitMEXOrderBook>(result);
 
             var data = new BitMEXOrderBook
             {
@@ -363,7 +366,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 Bids = result.Data.Where(x => x.Side == OrderSide.Buy).OrderByDescending(x => x.Price).ToArray()
             };
 
-            return result.As(data);
+            return HttpResult.Ok(result, data);
         }
 
         #endregion
@@ -371,7 +374,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Insurance
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXInsurance[]>> GetInsuranceAsync(
+        public async Task<HttpResult<BitMEXInsurance[]>> GetInsuranceAsync(
             string? asset = null,
             SymbolFilter? symbolFilter = null,
             Dictionary<string, object>? filter = null,
@@ -383,17 +386,17 @@ namespace BitMEX.Net.Clients.ExchangeApi
             int? offset = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             if (asset != null)
-                parameters.AddOptional("currency", asset + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
-            parameters.AddOptional("filter", filter);
-            parameters.AddOptional("columns", columns);
-            parameters.AddOptional("count", limit);
-            parameters.AddOptional("start", offset);
-            parameters.AddBoolString("reverse", reverse ?? true);
-            parameters.AddOptional("startTime", startTime?.ToRfc3339String());
-            parameters.AddOptional("endTime", endTime?.ToRfc3339String());
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/insurance", BitMEXExchange.RateLimiter.BitMEX, 1, false);
+                parameters.Add("currency", asset + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
+            parameters.AddRaw("filter", filter);
+            parameters.AddArray("columns", columns);
+            parameters.Add("count", limit);
+            parameters.Add("start", offset);
+            parameters.Add("reverse", reverse ?? true);
+            parameters.Add("startTime", startTime?.ToRfc3339String());
+            parameters.Add("endTime", endTime?.ToRfc3339String());
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/insurance", BitMEXExchange.RateLimiter.BitMEX, 1, false);
             return await _baseClient.SendAsync<BitMEXInsurance[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -402,7 +405,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Funding History
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXFundingRate[]>> GetFundingHistoryAsync(
+        public async Task<HttpResult<BitMEXFundingRate[]>> GetFundingHistoryAsync(
             string? symbol = null,
             SymbolFilter? symbolFilter = null,
             Dictionary<string, object>? filter = null,
@@ -414,17 +417,17 @@ namespace BitMEX.Net.Clients.ExchangeApi
             int? limit = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             if (symbol != null)
-                parameters.AddOptional("symbol", symbol + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
-            parameters.AddOptional("filter", filter);
-            parameters.AddOptional("columns", columns);
-            parameters.AddOptional("count", limit);
-            parameters.AddOptional("start", offset);
-            parameters.AddBoolString("reverse", reverse ?? true);
-            parameters.AddOptional("startTime", startTime?.ToRfc3339String());
-            parameters.AddOptional("endTime", endTime?.ToRfc3339String());
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/funding", BitMEXExchange.RateLimiter.BitMEX, 1, false);
+                parameters.Add("symbol", symbol + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
+            parameters.AddRaw("filter", filter);
+            parameters.AddArray("columns", columns);
+            parameters.Add("count", limit);
+            parameters.Add("start", offset);
+            parameters.Add("reverse", reverse ?? true);
+            parameters.Add("startTime", startTime?.ToRfc3339String());
+            parameters.Add("endTime", endTime?.ToRfc3339String());
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/funding", BitMEXExchange.RateLimiter.BitMEX, 1, false);
             return await _baseClient.SendAsync<BitMEXFundingRate[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -433,29 +436,28 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Announcements
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXAnnouncement[]>> GetAnnouncementsAsync(
+        public async Task<HttpResult<BitMEXAnnouncement[]>> GetAnnouncementsAsync(
             IEnumerable<string>? columns = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();            
-            parameters.AddOptional("columns", columns);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/announcement", BitMEXExchange.RateLimiter.BitMEX, 1, false);
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
+            parameters.AddArray("columns", columns);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/announcement", BitMEXExchange.RateLimiter.BitMEX, 1, false);
             return await _baseClient.SendAsync<BitMEXAnnouncement[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
         #endregion
 
-
         #region Get Urgent Announcements
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXAnnouncement[]>> GetUrgentAnnouncementsAsync(
+        public async Task<HttpResult<BitMEXAnnouncement[]>> GetUrgentAnnouncementsAsync(
             IEnumerable<string>? columns = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("columns", columns);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/announcement/urgent", BitMEXExchange.RateLimiter.BitMEX, 1, false);
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
+            parameters.AddArray("columns", columns);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/announcement/urgent", BitMEXExchange.RateLimiter.BitMEX, 1, false);
             return await _baseClient.SendAsync<BitMEXAnnouncement[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -464,9 +466,9 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Assets
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXAsset[]>> GetAssetsAsync(CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXAsset[]>> GetAssetsAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/wallet/assets", BitMEXExchange.RateLimiter.BitMEX, 1, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/wallet/assets", BitMEXExchange.RateLimiter.BitMEX, 1, false);
             return await _baseClient.SendAsync<BitMEXAsset[]>(request, null, ct).ConfigureAwait(false);
         }
 
@@ -475,9 +477,9 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Asset Networks
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXNetwork[]>> GetAssetNetworksAsync(CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXNetwork[]>> GetAssetNetworksAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/wallet/networks", BitMEXExchange.RateLimiter.BitMEX, 1, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/wallet/networks", BitMEXExchange.RateLimiter.BitMEX, 1, false);
             return await _baseClient.SendAsync<BitMEXNetwork[]>(request, null, ct).ConfigureAwait(false);
         }
 
@@ -486,7 +488,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Liquidations
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXLiquidation[]>> GetLiquidationsAsync(string? symbol = null,
+        public async Task<HttpResult<BitMEXLiquidation[]>> GetLiquidationsAsync(string? symbol = null,
             SymbolFilter? symbolFilter = null,
             Dictionary<string, object>? filter = null,
             IEnumerable<string>? columns = null,
@@ -497,17 +499,17 @@ namespace BitMEX.Net.Clients.ExchangeApi
             int? limit = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             if (symbol != null)
-                parameters.AddOptional("symbol", symbol + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
-            parameters.AddOptional("filter", filter);
-            parameters.AddOptional("columns", columns);
-            parameters.AddOptional("count", limit);
-            parameters.AddOptional("start", offset);
-            parameters.AddBoolString("reverse", reverse ?? true);
-            parameters.AddOptional("startTime", startTime?.ToRfc3339String());
-            parameters.AddOptional("endTime", endTime?.ToRfc3339String());
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/liquidation", BitMEXExchange.RateLimiter.BitMEX, 1, false);
+                parameters.Add("symbol", symbol + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
+            parameters.AddRaw("filter", filter);
+            parameters.AddArray("columns", columns);
+            parameters.Add("count", limit);
+            parameters.Add("start", offset);
+            parameters.Add("reverse", reverse ?? true);
+            parameters.Add("startTime", startTime?.ToRfc3339String());
+            parameters.Add("endTime", endTime?.ToRfc3339String());
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/liquidation", BitMEXExchange.RateLimiter.BitMEX, 1, false);
             return await _baseClient.SendAsync<BitMEXLiquidation[]>(request, parameters, ct).ConfigureAwait(false);
         }
 

--- a/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiShared.cs
+++ b/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiShared.cs
@@ -18,33 +18,33 @@ namespace BitMEX.Net.Clients.ExchangeApi
     {
         private const string _topicSpotId = "BitMEXSpot";
         private const string _topicFuturesId = "BitMEXFutures";
-
-        public string Exchange => "BitMEX";
+        private const string _exchangeName = "BitMEX";
 
         public TradingMode[] SupportedTradingModes => new[] { TradingMode.Spot, TradingMode.PerpetualLinear, TradingMode.DeliveryLinear, TradingMode.PerpetualInverse, TradingMode.DeliveryInverse };
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
 
 
         #region Asset client
-        EndpointOptions<GetAssetsRequest> IAssetsRestClient.GetAssetsOptions { get; } = new EndpointOptions<GetAssetsRequest>(true);
+        GetAssetsOptions IAssetsRestClient.GetAssetsOptions { get; } = new GetAssetsOptions(_exchangeName, true);
 
-        async Task<ExchangeWebResult<SharedAsset[]>> IAssetsRestClient.GetAssetsAsync(GetAssetsRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedAsset[]>> IAssetsRestClient.GetAssetsAsync(GetAssetsRequest request, CancellationToken ct)
         {
-            var validationError = ((IAssetsRestClient)this).GetAssetsOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetAssetsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedAsset[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedAsset[]>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedAsset[]>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedAsset[]>(Exchange, symbolInfoResult.Error!);
 
             var assets = await ExchangeData.GetAssetsAsync(ct: ct).ConfigureAwait(false);
-            if (!assets)
-                return assets.AsExchangeResult<SharedAsset[]>(Exchange, null, default);
+            if (!assets.Success)
+                return HttpResult.Fail<SharedAsset[]>(assets);
 
-            return assets.AsExchangeResult<SharedAsset[]>(Exchange, TradingMode.Spot, assets.Data.Select(x =>
+            return HttpResult.Ok(assets, assets.Data.Select(x =>
             {
                 return new SharedAsset(BitMEXExchange.AssetAliases.ExchangeToCommonName(x.Asset))
                 {
@@ -63,26 +63,26 @@ namespace BitMEX.Net.Clients.ExchangeApi
             }).ToArray());
         }
 
-        EndpointOptions<GetAssetRequest> IAssetsRestClient.GetAssetOptions { get; } = new EndpointOptions<GetAssetRequest>(false);
-        async Task<ExchangeWebResult<SharedAsset>> IAssetsRestClient.GetAssetAsync(GetAssetRequest request, CancellationToken ct)
+        GetAssetOptions IAssetsRestClient.GetAssetOptions { get; } = new GetAssetOptions(_exchangeName, false);
+        async Task<HttpResult<SharedAsset>> IAssetsRestClient.GetAssetAsync(GetAssetRequest request, CancellationToken ct)
         {
-            var validationError = ((IAssetsRestClient)this).GetAssetOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetAssetOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedAsset>(Exchange, validationError);
+                return HttpResult.Fail<SharedAsset>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedAsset>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedAsset>(Exchange, symbolInfoResult.Error!);
 
             var assets = await ExchangeData.GetAssetsAsync(ct: ct).ConfigureAwait(false);
-            if (!assets)
-                return assets.AsExchangeResult<SharedAsset>(Exchange, null, default);
+            if (!assets.Success)
+                return HttpResult.Fail<SharedAsset>(assets);
 
             var asset = assets.Data.SingleOrDefault(x => x.Asset == request.Asset || BitMEXExchange.AssetAliases.CommonToExchangeName(x.Asset) == request.Asset);
             if (asset == null)
-                return assets.AsExchangeError<SharedAsset>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownAsset, "Asset not found")));
+                return HttpResult.Fail<SharedAsset>(assets, new ServerError(new ErrorInfo(ErrorType.UnknownAsset, "Asset not found")));
 
-            return assets.AsExchangeResult<SharedAsset>(Exchange, TradingMode.Spot, 
+            return HttpResult.Ok(assets, 
                 new SharedAsset(BitMEXExchange.AssetAliases.ExchangeToCommonName(asset.Asset))
                 {
                     FullName = asset.Name,
@@ -103,23 +103,23 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #endregion
 
         #region Balance Client
-        GetBalancesOptions IBalanceRestClient.GetBalancesOptions { get; } = new GetBalancesOptions(AccountTypeFilter.Spot, AccountTypeFilter.Funding, AccountTypeFilter.Futures);
+        GetBalancesOptions IBalanceRestClient.GetBalancesOptions { get; } = new GetBalancesOptions(_exchangeName, AccountTypeFilter.Spot, AccountTypeFilter.Funding, AccountTypeFilter.Futures);
 
-        async Task<ExchangeWebResult<SharedBalance[]>> IBalanceRestClient.GetBalancesAsync(GetBalancesRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedBalance[]>> IBalanceRestClient.GetBalancesAsync(GetBalancesRequest request, CancellationToken ct)
         {
-            var validationError = ((IBalanceRestClient)this).GetBalancesOptions.ValidateRequest(Exchange, request, SupportedTradingModes);
+            var validationError = SharedClient.GetBalancesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedBalance[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedBalance[]>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedBalance[]>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedBalance[]>(Exchange, symbolInfoResult.Error!);
 
             var result = await Account.GetBalancesAsync(ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedBalance[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedBalance[]>(result);
 
-            return result.AsExchangeResult<SharedBalance[]>(Exchange, SupportedTradingModes, result.Data.Select(x => 
+            return HttpResult.Ok(result, result.Data.Select(x => 
                 new SharedBalance(
                     BitMEXExchange.AssetAliases.ExchangeToCommonName(BitMEXUtils.GetAssetFromCurrency(x.Currency) ?? x.Currency),
                     x.Quantity.ToSharedAssetQuantity(x.Currency) ?? 0,
@@ -131,39 +131,39 @@ namespace BitMEX.Net.Clients.ExchangeApi
 
         #region Deposit client
 
-        EndpointOptions<GetDepositAddressesRequest> IDepositRestClient.GetDepositAddressesOptions { get; } = new EndpointOptions<GetDepositAddressesRequest>(true)
+        GetDepositAddressesOptions IDepositRestClient.GetDepositAddressesOptions { get; } = new GetDepositAddressesOptions(_exchangeName, true)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
                 new ParameterDescription(nameof(GetDepositAddressesRequest.Network), typeof(string), "Network to use", "btc")
             }
         };
-        async Task<ExchangeWebResult<SharedDepositAddress[]>> IDepositRestClient.GetDepositAddressesAsync(GetDepositAddressesRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedDepositAddress[]>> IDepositRestClient.GetDepositAddressesAsync(GetDepositAddressesRequest request, CancellationToken ct)
         {
-            var validationError = ((IDepositRestClient)this).GetDepositAddressesOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetDepositAddressesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedDepositAddress[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedDepositAddress[]>(Exchange, validationError);
 
             var depositAddresses = await Account.GetDepositAddressAsync(BitMEXExchange.AssetAliases.CommonToExchangeName(request.Asset), request.Network!, ct: ct).ConfigureAwait(false);
-            if (!depositAddresses)
-                return depositAddresses.AsExchangeResult<SharedDepositAddress[]>(Exchange, null, default);
+            if (!depositAddresses.Success)
+                return HttpResult.Fail<SharedDepositAddress[]>(depositAddresses);
 
-            return depositAddresses.AsExchangeResult<SharedDepositAddress[]>(Exchange, TradingMode.Spot, new[] { new SharedDepositAddress(request.Asset, depositAddresses.Data) });
+            return HttpResult.Ok(depositAddresses, new[] { new SharedDepositAddress(request.Asset, depositAddresses.Data) });
         }
 
-        GetDepositsOptions IDepositRestClient.GetDepositsOptions { get; } = new GetDepositsOptions(true, true, false, 10000)
+        GetDepositsOptions IDepositRestClient.GetDepositsOptions { get; } = new GetDepositsOptions(_exchangeName, true, true, false, 10000)
         {
             RequestNotes = "Due to the API not offering a filter on deposit type less results may be returned per page"
         };
-        async Task<ExchangeWebResult<SharedDeposit[]>> IDepositRestClient.GetDepositsAsync(GetDepositsRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedDeposit[]>> IDepositRestClient.GetDepositsAsync(GetDepositsRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IDepositRestClient)this).GetDepositsOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetDepositsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedDeposit[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedDeposit[]>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedDeposit[]>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedDeposit[]>(Exchange, symbolInfoResult.Error!);
 
             var direction = request.Direction ?? DataDirection.Descending;
             var limit = request.Limit ?? 100;
@@ -176,8 +176,8 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 offset: pageParams.Offset,
                 reverse: direction == DataDirection.Descending,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedDeposit[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedDeposit[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                 () => Pagination.NextPageFromOffset(pageParams, result.Data.Length),
@@ -187,10 +187,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 request.EndTime ?? DateTime.UtcNow,
                 pageParams);
 
-            return result.AsExchangeResult(
-                       Exchange,
-                       TradingMode.Spot,
-                       ExchangeHelpers.ApplyFilter(result.Data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
                        .Where(x => x.TransactionType == TransactionType.Deposit)
                        .Select(x => 
                             new SharedDeposit(
@@ -222,48 +219,48 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #endregion
 
         #region Fee Client
-        EndpointOptions<GetFeeRequest> IFeeRestClient.GetFeeOptions { get; } = new EndpointOptions<GetFeeRequest>(true);
+        GetFeeOptions IFeeRestClient.GetFeeOptions { get; } = new GetFeeOptions(_exchangeName, true);
 
-        async Task<ExchangeWebResult<SharedFee>> IFeeRestClient.GetFeesAsync(GetFeeRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedFee>> IFeeRestClient.GetFeesAsync(GetFeeRequest request, CancellationToken ct)
         {
-            var validationError = ((IFeeRestClient)this).GetFeeOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFeeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFee>(Exchange, validationError);
+                return HttpResult.Fail<SharedFee>(Exchange, validationError);
 
             // Get data
             var result = await Account.GetFeesAsync(ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedFee>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFee>(result);
 
             if(!result.Data.TryGetValue(request.Symbol!.GetSymbol(FormatSymbol), out var fees))
-                return result.AsExchangeError<SharedFee>(Exchange, new ServerError(new ErrorInfo(ErrorType.Unknown, "Not found")));
+                return HttpResult.Fail<SharedFee>(result, new ServerError(new ErrorInfo(ErrorType.Unknown, "Not found")));
 
             // Return
-            return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedFee(fees.MakerFee * 100, fees.TakerFee * 100));
+            return HttpResult.Ok(result, new SharedFee(fees.MakerFee * 100, fees.TakerFee * 100));
         }
         #endregion
 
         #region Klines Client
 
-        GetKlinesOptions IKlineRestClient.GetKlinesOptions { get; } = new GetKlinesOptions(false, true, true, 1000, false,
+        GetKlinesOptions IKlineRestClient.GetKlinesOptions { get; } = new GetKlinesOptions(_exchangeName, false, true, true, 1000, false,
             SharedKlineInterval.OneMinute,
             SharedKlineInterval.FiveMinutes,
             SharedKlineInterval.OneHour,
             SharedKlineInterval.OneDay);
 
-        async Task<ExchangeWebResult<SharedKline[]>> IKlineRestClient.GetKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedKline[]>> IKlineRestClient.GetKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
             var interval = (Enums.BinPeriod)request.Interval;
             if (!Enum.IsDefined(typeof(Enums.BinPeriod), interval))
-                return new ExchangeWebResult<SharedKline[]>(Exchange, ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
+                return HttpResult.Fail<SharedKline[]>(Exchange, ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
 
-            var validationError = ((IKlineRestClient)this).GetKlinesOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetKlinesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedKline[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedKline[]>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedKline[]>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedKline[]>(Exchange, symbolInfoResult.Error!);
 
             var direction = DataDirection.Descending;
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
@@ -283,8 +280,8 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 reverse: direction == DataDirection.Descending,
                 ct: ct
                 ).ConfigureAwait(false);
-            if (!result)
-                return new ExchangeWebResult<SharedKline[]>(Exchange, request.Symbol!.TradingMode, result.As<SharedKline[]>(default));
+            if (!result.Success)
+                return HttpResult.Fail<SharedKline[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                     () => Pagination.NextPageFromOffset(pageParams, result.Data.Length),
@@ -294,10 +291,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                     request.EndTime ?? DateTime.UtcNow,
                     pageParams);
 
-            return result.AsExchangeResult(
-                   Exchange,
-                   TradingMode.Spot,
-                   ExchangeHelpers.ApplyFilter(result.Data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
                    .Select(x =>
                         new SharedKline(
                             request.Symbol, 
@@ -314,23 +308,23 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #endregion
 
         #region Order Book client
-        GetOrderBookOptions IOrderBookRestClient.GetOrderBookOptions { get; } = new GetOrderBookOptions(1, 5000, false);
-        async Task<ExchangeWebResult<SharedOrderBook>> IOrderBookRestClient.GetOrderBookAsync(GetOrderBookRequest request, CancellationToken ct)
+        GetOrderBookOptions IOrderBookRestClient.GetOrderBookOptions { get; } = new GetOrderBookOptions(_exchangeName, 1, 5000, false);
+        async Task<HttpResult<SharedOrderBook>> IOrderBookRestClient.GetOrderBookAsync(GetOrderBookRequest request, CancellationToken ct)
         {
-            var validationError = ((IOrderBookRestClient)this).GetOrderBookOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetOrderBookOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedOrderBook>(Exchange, validationError);
+                return HttpResult.Fail<SharedOrderBook>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedOrderBook>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedOrderBook>(Exchange, symbolInfoResult.Error!);
 
             var result = await ExchangeData.GetOrderBookAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
                 limit: request.Limit ?? 20,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedOrderBook>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedOrderBook>(result);
 
             var book = new SharedOrderBook(result.Data.Asks, result.Data.Bids);
             if (request.Symbol!.TradingMode == TradingMode.Spot)
@@ -341,23 +335,23 @@ namespace BitMEX.Net.Clients.ExchangeApi
                     item.Quantity = ((long)item.Quantity).ToSharedAssetQuantity(request.Symbol!.BaseAsset) ?? 0;
             }
 
-            return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, book);
+            return HttpResult.Ok(result, book);
         }
 
         #endregion
 
         #region Recent Trades client
-        GetRecentTradesOptions IRecentTradeRestClient.GetRecentTradesOptions { get; } = new GetRecentTradesOptions(1000, false);
+        GetRecentTradesOptions IRecentTradeRestClient.GetRecentTradesOptions { get; } = new GetRecentTradesOptions(_exchangeName, 1000, false);
 
-        async Task<ExchangeWebResult<SharedTrade[]>> IRecentTradeRestClient.GetRecentTradesAsync(GetRecentTradesRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedTrade[]>> IRecentTradeRestClient.GetRecentTradesAsync(GetRecentTradesRequest request, CancellationToken ct)
         {
-            var validationError = ((IRecentTradeRestClient)this).GetRecentTradesOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetRecentTradesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedTrade[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedTrade[]>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedTrade[]>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedTrade[]>(Exchange, symbolInfoResult.Error!);
 
             // Get data
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
@@ -365,11 +359,11 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 symbol,
                 limit: request.Limit,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedTrade[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedTrade[]>(result);
 
             // Return
-            return result.AsExchangeResult<SharedTrade[]>(Exchange, request.Symbol!.TradingMode, result.Data.Select(x => 
+            return HttpResult.Ok(result, result.Data.Select(x => 
             new SharedTrade(request.Symbol, symbol, x.Quantity.ToSharedSymbolQuantity(symbol) ?? 0, x.Price, x.Timestamp)
             {
                 Side = x.Side == OrderSide.Sell ? SharedOrderSide.Sell : SharedOrderSide.Buy,
@@ -378,17 +372,17 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #endregion
 
         #region Trade History client
-        GetTradeHistoryOptions ITradeHistoryRestClient.GetTradeHistoryOptions { get; } = new GetTradeHistoryOptions(true, true, true, 1000, false);
+        GetTradeHistoryOptions ITradeHistoryRestClient.GetTradeHistoryOptions { get; } = new GetTradeHistoryOptions(_exchangeName, true, true, true, 1000, false);
 
-        async Task<ExchangeWebResult<SharedTrade[]>> ITradeHistoryRestClient.GetTradeHistoryAsync(GetTradeHistoryRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedTrade[]>> ITradeHistoryRestClient.GetTradeHistoryAsync(GetTradeHistoryRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((ITradeHistoryRestClient)this).GetTradeHistoryOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetTradeHistoryOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedTrade[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedTrade[]>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedTrade[]>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedTrade[]>(Exchange, symbolInfoResult.Error!);
 
             var direction = request.Direction ?? DataDirection.Descending;
             var limit = request.Limit ?? 1000;
@@ -404,8 +398,8 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 offset: pageParams.Offset,
                 reverse: direction == DataDirection.Descending,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedTrade[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedTrade[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                 () => Pagination.NextPageFromOffset(pageParams, result.Data.Length),
@@ -416,10 +410,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 pageParams);
 
             // Return
-            return result.AsExchangeResult(
-                       Exchange,
-                       TradingMode.Spot,
-                       ExchangeHelpers.ApplyFilter(result.Data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
                        .Select(x => 
                             new SharedTrade(request.Symbol, symbol, x.Quantity.ToSharedSymbolQuantity(symbol) ?? 0, x.Price, x.Timestamp)
                             {
@@ -431,25 +422,25 @@ namespace BitMEX.Net.Clients.ExchangeApi
 
         #region Book Ticker client
 
-        EndpointOptions<GetBookTickerRequest> IBookTickerRestClient.GetBookTickerOptions { get; } = new EndpointOptions<GetBookTickerRequest>(false);
-        async Task<ExchangeWebResult<SharedBookTicker>> IBookTickerRestClient.GetBookTickerAsync(GetBookTickerRequest request, CancellationToken ct)
+        GetBookTickerOptions IBookTickerRestClient.GetBookTickerOptions { get; } = new GetBookTickerOptions(_exchangeName, false);
+        async Task<HttpResult<SharedBookTicker>> IBookTickerRestClient.GetBookTickerAsync(GetBookTickerRequest request, CancellationToken ct)
         {
-            var validationError = ((IBookTickerRestClient)this).GetBookTickerOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetBookTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedBookTicker>(Exchange, validationError);
+                return HttpResult.Fail<SharedBookTicker>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedBookTicker>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedBookTicker>(Exchange, symbolInfoResult.Error!);
 
             var resultTicker = await ExchangeData.GetBookTickerHistoryAsync(request.Symbol!.GetSymbol(FormatSymbol), reverse: true, limit: 1, ct: ct).ConfigureAwait(false);
-            if (!resultTicker)
-                return resultTicker.AsExchangeResult<SharedBookTicker>(Exchange, null, default);
+            if (!resultTicker.Success)
+                return HttpResult.Fail<SharedBookTicker>(resultTicker);
 
             if (!resultTicker.Data.Any())
-                return resultTicker.AsExchangeError<SharedBookTicker>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                return HttpResult.Fail<SharedBookTicker>(resultTicker, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-            return resultTicker.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedBookTicker(
+            return HttpResult.Ok(resultTicker, new SharedBookTicker(
                 ExchangeSymbolCache.ParseSymbol(request.Symbol!.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, resultTicker.Data[0].Symbol),
                 resultTicker.Data[0].Symbol,
                 resultTicker.Data[0].BestAskPrice,
@@ -462,19 +453,19 @@ namespace BitMEX.Net.Clients.ExchangeApi
 
         #region Withdrawal client
 
-        GetWithdrawalsOptions IWithdrawalRestClient.GetWithdrawalsOptions { get; } = new GetWithdrawalsOptions(true, true, true, 1000)
+        GetWithdrawalsOptions IWithdrawalRestClient.GetWithdrawalsOptions { get; } = new GetWithdrawalsOptions(_exchangeName, true, true, true, 1000)
         {
             RequestNotes = "Due to the API not offering a filter on withdrawal type less results may be returned per page"
         };
-        async Task<ExchangeWebResult<SharedWithdrawal[]>> IWithdrawalRestClient.GetWithdrawalsAsync(GetWithdrawalsRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedWithdrawal[]>> IWithdrawalRestClient.GetWithdrawalsAsync(GetWithdrawalsRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IWithdrawalRestClient)this).GetWithdrawalsOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetWithdrawalsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedWithdrawal[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedWithdrawal[]>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedWithdrawal[]>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedWithdrawal[]>(Exchange, symbolInfoResult.Error!);
 
             var direction = request.Direction ?? DataDirection.Descending;
             var limit = request.Limit ?? 100;
@@ -488,8 +479,8 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 offset: pageParams.Offset,
                 reverse: direction == DataDirection.Descending,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedWithdrawal[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedWithdrawal[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                 () => Pagination.NextPageFromOffset(pageParams, result.Data.Length),
@@ -499,10 +490,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 request.EndTime ?? DateTime.UtcNow,
                 pageParams);
 
-            return result.AsExchangeResult(
-                       Exchange,
-                       TradingMode.Spot,
-                       ExchangeHelpers.ApplyFilter(result.Data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
                        .Where(x => x.TransactionType == TransactionType.Withdrawal)
                        .Select(x => 
                             new SharedWithdrawal(
@@ -525,22 +513,22 @@ namespace BitMEX.Net.Clients.ExchangeApi
 
         #region Withdraw client
 
-        WithdrawOptions IWithdrawRestClient.WithdrawOptions { get; } = new WithdrawOptions()
+        WithdrawOptions IWithdrawRestClient.WithdrawOptions { get; } = new WithdrawOptions(_exchangeName)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
                 new ParameterDescription(nameof(WithdrawRequest.Network), typeof(string), "Network to use", "btc")
             }
         };
-        async Task<ExchangeWebResult<SharedId>> IWithdrawRestClient.WithdrawAsync(WithdrawRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> IWithdrawRestClient.WithdrawAsync(WithdrawRequest request, CancellationToken ct)
         {
-            var validationError = ((IWithdrawRestClient)this).WithdrawOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.WithdrawOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedId>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedId>(Exchange, symbolInfoResult.Error!);
 
             // Get data
             var withdrawal = await Account.WithdrawAsync(
@@ -550,32 +538,32 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 request.Address,
                 memo: request.AddressTag,
                 ct: ct).ConfigureAwait(false);
-            if (!withdrawal)
-                return withdrawal.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!withdrawal.Success)
+                return HttpResult.Fail<SharedId>(withdrawal);
 
-            return withdrawal.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(withdrawal.Data.TransactionId));
+            return HttpResult.Ok(withdrawal, new SharedId(withdrawal.Data.TransactionId));
         }
 
         #endregion
 
         #region Spot Symbol client
-        EndpointOptions<GetSymbolsRequest> ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new EndpointOptions<GetSymbolsRequest>(false);
+        GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
 
-        async Task<ExchangeWebResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotSymbolRestClient)this).GetSpotSymbolsOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotSymbolsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotSymbol[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotSymbol[]>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedSpotSymbol[]>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedSpotSymbol[]>(Exchange, symbolInfoResult.Error!);
 
             var result = await ExchangeData.GetActiveSymbolsAsync(ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedSpotSymbol[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedSpotSymbol[]>(result);
 
-            var response = result.AsExchangeResult<SharedSpotSymbol[]>(Exchange, TradingMode.Spot, result.Data.Where(x => x.SymbolType == SymbolType.Spot).Select(s => 
+            var response = HttpResult.Ok(result, result.Data.Where(x => x.SymbolType == SymbolType.Spot).Select(s => 
                 new SharedSpotSymbol(BitMEXExchange.AssetAliases.ExchangeToCommonName(s.BaseAsset), BitMEXExchange.AssetAliases.ExchangeToCommonName(s.QuoteAsset), s.Symbol, s.Status == SymbolStatus.Open)
                 {
                     MinTradeQuantity = s.LotSize.ToSharedSymbolQuantity(s.Symbol),
@@ -584,23 +572,23 @@ namespace BitMEX.Net.Clients.ExchangeApi
                     PriceStep = s.PriceStep
                 }).ToArray());
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicSpotId, response.Data);
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicSpotId, response.Data!);
             return response;
         }
 
-        async Task<ExchangeResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)
+        async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)
         {
             if (!ExchangeSymbolCache.HasCached(_topicSpotId))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<SharedSymbol[]>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<SharedSymbol[]>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<SharedSymbol[]>(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicSpotId, baseAsset));
+            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicSpotId, baseAsset));
         }
 
-        async Task<ExchangeResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(SharedSymbol symbol)
+        async Task<ExchangeCallResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(SharedSymbol symbol)
         {
             if (symbol.TradingMode != TradingMode.Spot)
                 throw new ArgumentException(nameof(symbol), "Only Spot symbols allowed");
@@ -608,48 +596,48 @@ namespace BitMEX.Net.Clients.ExchangeApi
             if (!ExchangeSymbolCache.HasCached(_topicSpotId))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<bool>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, symbol));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, symbol));
         }
 
-        async Task<ExchangeResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(string symbolName)
+        async Task<ExchangeCallResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(string symbolName)
         {
             if (!ExchangeSymbolCache.HasCached(_topicSpotId))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<bool>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, symbolName));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, symbolName));
         }
         #endregion
 
         #region Spot Ticker client
 
-        GetTickerOptions ISpotTickerRestClient.GetSpotTickerOptions { get; } = new GetTickerOptions();
-        async Task<ExchangeWebResult<SharedSpotTicker>> ISpotTickerRestClient.GetSpotTickerAsync(GetTickerRequest request, CancellationToken ct)
+        GetSpotTickerOptions ISpotTickerRestClient.GetSpotTickerOptions { get; } = new GetSpotTickerOptions(_exchangeName);
+        async Task<HttpResult<SharedSpotTicker>> ISpotTickerRestClient.GetSpotTickerAsync(GetTickerRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotTickerRestClient)this).GetSpotTickerOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotTicker>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotTicker>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedSpotTicker>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedSpotTicker>(Exchange, symbolInfoResult.Error!);
 
             var result = await ExchangeData.GetActiveSymbolsAsync(ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedSpotTicker>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedSpotTicker>(result);
 
             var symbol = result.Data.SingleOrDefault(x => x.Symbol == request.Symbol!.GetSymbol(FormatSymbol));
             if (symbol == null)
-                return result.AsExchangeError<SharedSpotTicker>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                return HttpResult.Fail<SharedSpotTicker>(result, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-            return result.AsExchangeResult(Exchange, TradingMode.Spot, new SharedSpotTicker(
+            return HttpResult.Ok(result, new SharedSpotTicker(
                 ExchangeSymbolCache.ParseSymbol(_topicSpotId, symbol.Symbol),
                 symbol.Symbol,
                 symbol.LastPrice,
@@ -663,22 +651,22 @@ namespace BitMEX.Net.Clients.ExchangeApi
             });
         }
 
-        GetTickersOptions ISpotTickerRestClient.GetSpotTickersOptions { get; } = new GetTickersOptions();
-        async Task<ExchangeWebResult<SharedSpotTicker[]>> ISpotTickerRestClient.GetSpotTickersAsync(GetTickersRequest request, CancellationToken ct)
+        GetSpotTickersOptions ISpotTickerRestClient.GetSpotTickersOptions { get; } = new GetSpotTickersOptions(_exchangeName);
+        async Task<HttpResult<SharedSpotTicker[]>> ISpotTickerRestClient.GetSpotTickersAsync(GetTickersRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotTickerRestClient)this).GetSpotTickersOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotTickersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotTicker[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotTicker[]>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedSpotTicker[]>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedSpotTicker[]>(Exchange, symbolInfoResult.Error!);
 
             var result = await ExchangeData.GetActiveSymbolsAsync(ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedSpotTicker[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedSpotTicker[]>(result);
 
-            return result.AsExchangeResult<SharedSpotTicker[]>(Exchange, TradingMode.Spot, result.Data.Where(x => x.SymbolType == SymbolType.Spot).Select(x =>
+            return HttpResult.Ok(result, result.Data.Where(x => x.SymbolType == SymbolType.Spot).Select(x =>
             new SharedSpotTicker(
                 ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol),
                 x.Symbol,
@@ -707,23 +695,16 @@ namespace BitMEX.Net.Clients.ExchangeApi
 
         string ISpotOrderRestClient.GenerateClientOrderId() => ExchangeHelpers.RandomString(32);
 
-        PlaceSpotOrderOptions ISpotOrderRestClient.PlaceSpotOrderOptions { get; } = new PlaceSpotOrderOptions();
-        async Task<ExchangeWebResult<SharedId>> ISpotOrderRestClient.PlaceSpotOrderAsync(PlaceSpotOrderRequest request, CancellationToken ct)
+        PlaceSpotOrderOptions ISpotOrderRestClient.PlaceSpotOrderOptions { get; } = new PlaceSpotOrderOptions(_exchangeName);
+        async Task<HttpResult<SharedId>> ISpotOrderRestClient.PlaceSpotOrderAsync(PlaceSpotOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).PlaceSpotOrderOptions.ValidateRequest(
-                Exchange,
-                request,
-                request.Symbol!.TradingMode,
-                SupportedTradingModes,
-                ((ISpotOrderRestClient)this).SpotSupportedOrderTypes,
-                ((ISpotOrderRestClient)this).SpotSupportedTimeInForce,
-                ((ISpotOrderRestClient)this).SpotSupportedOrderQuantity);
+            var validationError = SharedClient.PlaceSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedId>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedId>(Exchange, symbolInfoResult.Error!);
 
             var result = await Trading.PlaceOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
@@ -736,22 +717,22 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 clientOrderId: request.ClientOrderId,
                 ct: ct).ConfigureAwait(false);
 
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
-            return result.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(result.Data.OrderId));
+            return HttpResult.Ok(result, new SharedId(result.Data.OrderId));
         }
 
-        EndpointOptions<GetOrderRequest> ISpotOrderRestClient.GetSpotOrderOptions { get; } = new EndpointOptions<GetOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedSpotOrder>> ISpotOrderRestClient.GetSpotOrderAsync(GetOrderRequest request, CancellationToken ct)
+        GetSpotOrderOptions ISpotOrderRestClient.GetSpotOrderOptions { get; } = new GetSpotOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedSpotOrder>> ISpotOrderRestClient.GetSpotOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetSpotOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotOrder>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotOrder>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedSpotOrder>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedSpotOrder>(Exchange, symbolInfoResult.Error!);
 
             var orders = await Trading.GetOrdersAsync(request.Symbol!.GetSymbol(FormatSymbol), 
                 filter: new Dictionary<string, object>
@@ -759,14 +740,14 @@ namespace BitMEX.Net.Clients.ExchangeApi
                     { "orderID", request.OrderId }
                 },
                 ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return orders.AsExchangeResult<SharedSpotOrder>(Exchange, null, default);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedSpotOrder>(orders);
 
             var order = orders.Data.SingleOrDefault();
             if (order == null)
-                return orders.AsExchangeError<SharedSpotOrder>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
+                return HttpResult.Fail<SharedSpotOrder>(orders, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
 
-            return orders.AsExchangeResult(Exchange, TradingMode.Spot, new SharedSpotOrder(
+            return HttpResult.Ok(orders, new SharedSpotOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicSpotId, order.Symbol),
                 order.Symbol,
                 order.OrderId,
@@ -787,16 +768,16 @@ namespace BitMEX.Net.Clients.ExchangeApi
             });
         }
 
-        EndpointOptions<GetOpenOrdersRequest> ISpotOrderRestClient.GetOpenSpotOrdersOptions { get; } = new EndpointOptions<GetOpenOrdersRequest>(true);
-        async Task<ExchangeWebResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetOpenSpotOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
+        GetOpenSpotOrdersOptions ISpotOrderRestClient.GetOpenSpotOrdersOptions { get; } = new GetOpenSpotOrdersOptions(_exchangeName, true);
+        async Task<HttpResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetOpenSpotOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetOpenSpotOrdersOptions.ValidateRequest(Exchange, request, request.Symbol?.TradingMode ?? request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetOpenSpotOrdersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotOrder[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotOrder[]>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedSpotOrder[]>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedSpotOrder[]>(Exchange, symbolInfoResult.Error!);
 
             var symbol = request.Symbol?.GetSymbol(FormatSymbol);
             var orders = await Trading.GetOrdersAsync(symbol,
@@ -805,11 +786,11 @@ namespace BitMEX.Net.Clients.ExchangeApi
                     { "open", true }
                 },
                 ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return orders.AsExchangeResult<SharedSpotOrder[]>(Exchange, null, default);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedSpotOrder[]>(orders);
 
             var data = orders.Data.Where(x => BitMEXUtils.GetSymbolType(x.Symbol) == SymbolType.Spot);
-            return orders.AsExchangeResult<SharedSpotOrder[]>(Exchange, TradingMode.Spot, data.Select(x => new SharedSpotOrder(
+            return HttpResult.Ok(orders, data.Select(x => new SharedSpotOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol),
                 x.Symbol,
                 x.OrderId,
@@ -830,16 +811,16 @@ namespace BitMEX.Net.Clients.ExchangeApi
             }).ToArray());
         }
 
-        GetClosedOrdersOptions ISpotOrderRestClient.GetClosedSpotOrdersOptions { get; } = new GetClosedOrdersOptions(true, true, true, 500);
-        async Task<ExchangeWebResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetClosedSpotOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageRequest, CancellationToken ct)
+        GetSpotClosedOrdersOptions ISpotOrderRestClient.GetClosedSpotOrdersOptions { get; } = new GetSpotClosedOrdersOptions(_exchangeName, true, true, true, 500);
+        async Task<HttpResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetClosedSpotOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetClosedSpotOrdersOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetClosedSpotOrdersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotOrder[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotOrder[]>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedSpotOrder[]>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedSpotOrder[]>(Exchange, symbolInfoResult.Error!);
 
             var direction = request.Direction ?? DataDirection.Descending;
             var limit = request.Limit ?? 500;
@@ -857,8 +838,8 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 offset: pageParams.Offset,
                 reverse: direction == DataDirection.Descending,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedSpotOrder[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedSpotOrder[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                 () => Pagination.NextPageFromOffset(pageParams, result.Data.Length),
@@ -868,10 +849,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 request.EndTime ?? DateTime.UtcNow,
                 pageParams);
 
-            return result.AsExchangeResult(
-                       Exchange,
-                       TradingMode.Spot,
-                       ExchangeHelpers.ApplyFilter(result.Data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
                        .Select(x => 
                            new SharedSpotOrder(
                                 ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), 
@@ -895,16 +873,16 @@ namespace BitMEX.Net.Clients.ExchangeApi
                        .ToArray(), nextPageRequest);
         }
 
-        EndpointOptions<GetOrderTradesRequest> ISpotOrderRestClient.GetSpotOrderTradesOptions { get; } = new EndpointOptions<GetOrderTradesRequest>(true);
-        async Task<ExchangeWebResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
+        GetSpotOrderTradesOptions ISpotOrderRestClient.GetSpotOrderTradesOptions { get; } = new GetSpotOrderTradesOptions(_exchangeName, true);
+        async Task<HttpResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetSpotOrderTradesOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotOrderTradesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, symbolInfoResult.Error!);
 
             var trades = await Trading.GetUserTradesAsync(symbol: request.Symbol!.GetSymbol(FormatSymbol),
                 filter: new Dictionary<string, object>
@@ -912,10 +890,10 @@ namespace BitMEX.Net.Clients.ExchangeApi
                     { "orderID", request.OrderId }
                 },
                 ct: ct).ConfigureAwait(false);
-            if (!trades)
-                return trades.AsExchangeResult<SharedUserTrade[]>(Exchange, null, default);
+            if (!trades.Success)
+                return HttpResult.Fail<SharedUserTrade[]>(trades);
 
-            return trades.AsExchangeResult<SharedUserTrade[]>(Exchange, TradingMode.Spot, trades.Data.Select(x => new SharedUserTrade(
+            return HttpResult.Ok(trades, trades.Data.Select(x => new SharedUserTrade(
                 ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), 
                 x.Symbol,
                 x.OrderId,
@@ -931,16 +909,16 @@ namespace BitMEX.Net.Clients.ExchangeApi
             }).ToArray());
         }
 
-        GetUserTradesOptions ISpotOrderRestClient.GetSpotUserTradesOptions { get; } = new GetUserTradesOptions(true, true, true, 1000);
-        async Task<ExchangeWebResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        GetSpotUserTradesOptions ISpotOrderRestClient.GetSpotUserTradesOptions { get; } = new GetSpotUserTradesOptions(_exchangeName, true, true, true, 1000);
+        async Task<HttpResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetSpotUserTradesOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotUserTradesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, symbolInfoResult.Error!);
 
             var direction = request.Direction ?? DataDirection.Descending;
             var limit = request.Limit ?? 500;
@@ -955,8 +933,8 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 reverse: direction == DataDirection.Descending,
                 ct: ct
                 ).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedUserTrade[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedUserTrade[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                 () => Pagination.NextPageFromOffset(pageParams, result.Data.Length),
@@ -966,10 +944,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                  request.EndTime ?? DateTime.UtcNow,
                  pageParams);
 
-            return result.AsExchangeResult(
-                       Exchange,
-                       TradingMode.Spot,
-                       ExchangeHelpers.ApplyFilter(result.Data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
                        .Select(x => 
                            new SharedUserTrade(
                                 ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), 
@@ -988,18 +963,18 @@ namespace BitMEX.Net.Clients.ExchangeApi
                        .ToArray(), nextPageRequest);
         }
 
-        EndpointOptions<CancelOrderRequest> ISpotOrderRestClient.CancelSpotOrderOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> ISpotOrderRestClient.CancelSpotOrderAsync(CancelOrderRequest request, CancellationToken ct)
+        CancelSpotOrderOptions ISpotOrderRestClient.CancelSpotOrderOptions { get; } = new CancelSpotOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedId>> ISpotOrderRestClient.CancelSpotOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).CancelSpotOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.CancelSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var order = await Trading.CancelOrderAsync(request.OrderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return order.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(order.Data.OrderId));
+            return HttpResult.Ok(order, new SharedId(order.Data.OrderId));
         }
 
         private Enums.TimeInForce? GetTimeInForce(SharedTimeInForce? tif)
@@ -1042,16 +1017,16 @@ namespace BitMEX.Net.Clients.ExchangeApi
 
         #region Spot Client Id Order Client
 
-        EndpointOptions<GetOrderRequest> ISpotOrderClientIdRestClient.GetSpotOrderByClientOrderIdOptions { get; } = new EndpointOptions<GetOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedSpotOrder>> ISpotOrderClientIdRestClient.GetSpotOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
+        GetSpotOrderByClientOrderIdOptions ISpotOrderClientIdRestClient.GetSpotOrderByClientOrderIdOptions { get; } = new GetSpotOrderByClientOrderIdOptions(_exchangeName, true);
+        async Task<HttpResult<SharedSpotOrder>> ISpotOrderClientIdRestClient.GetSpotOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetSpotOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotOrder>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotOrder>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedSpotOrder>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedSpotOrder>(Exchange, symbolInfoResult.Error!);
 
             var orders = await Trading.GetOrdersAsync(request.Symbol!.GetSymbol(FormatSymbol),
                 filter: new Dictionary<string, object>
@@ -1059,14 +1034,14 @@ namespace BitMEX.Net.Clients.ExchangeApi
                     { "clOrdID", request.OrderId }
                 },
                 ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return orders.AsExchangeResult<SharedSpotOrder>(Exchange, null, default);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedSpotOrder>(orders);
 
             var order = orders.Data.SingleOrDefault();
             if (order == null)
-                return orders.AsExchangeError<SharedSpotOrder>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
+                return HttpResult.Fail<SharedSpotOrder>(orders, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
 
-            return orders.AsExchangeResult(Exchange, TradingMode.Spot, new SharedSpotOrder(
+            return HttpResult.Ok(orders, new SharedSpotOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicSpotId, order.Symbol),
                 order.Symbol,
                 order.OrderId,
@@ -1087,29 +1062,29 @@ namespace BitMEX.Net.Clients.ExchangeApi
             });
         }
 
-        EndpointOptions<CancelOrderRequest> ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
+        CancelSpotOrderByClientOrderIdOptions ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdOptions { get; } = new CancelSpotOrderByClientOrderIdOptions(_exchangeName, true);
+        async Task<HttpResult<SharedId>> ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).CancelSpotOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.CancelSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var order = await Trading.CancelOrderAsync(clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return order.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(order.Data.OrderId));
+            return HttpResult.Ok(order, new SharedId(order.Data.OrderId));
         }
         #endregion
 
         #region Funding Rate client
-        GetFundingRateHistoryOptions IFundingRateRestClient.GetFundingRateHistoryOptions { get; } = new GetFundingRateHistoryOptions(true, true, true, 500, false);
+        GetFundingRateHistoryOptions IFundingRateRestClient.GetFundingRateHistoryOptions { get; } = new GetFundingRateHistoryOptions(_exchangeName, true, true, true, 500, false);
 
-        async Task<ExchangeWebResult<SharedFundingRate[]>> IFundingRateRestClient.GetFundingRateHistoryAsync(GetFundingRateHistoryRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedFundingRate[]>> IFundingRateRestClient.GetFundingRateHistoryAsync(GetFundingRateHistoryRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IFundingRateRestClient)this).GetFundingRateHistoryOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFundingRateHistoryOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFundingRate[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFundingRate[]>(Exchange, validationError);
 
             var direction = request.Direction ?? DataDirection.Descending;
             var limit = request.Limit ?? 500;
@@ -1124,8 +1099,8 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 offset: pageParams.Offset,
                 reverse: direction == DataDirection.Descending,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedFundingRate[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFundingRate[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                 () => Pagination.NextPageFromOffset(pageParams, result.Data.Length),
@@ -1135,10 +1110,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                  request.EndTime ?? DateTime.UtcNow,
                  pageParams);
 
-            return result.AsExchangeResult(
-                       Exchange,
-                       TradingMode.Spot,
-                       ExchangeHelpers.ApplyFilter(result.Data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
                        .Select(x => 
                             new SharedFundingRate(x.FundingRate, x.Timestamp))
                        .ToArray(), nextPageRequest);
@@ -1147,20 +1119,20 @@ namespace BitMEX.Net.Clients.ExchangeApi
 
         #region Futures Symbol client
 
-        EndpointOptions<GetSymbolsRequest> IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new EndpointOptions<GetSymbolsRequest>(false);
-        async Task<ExchangeWebResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
+        GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
+        async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesSymbolRestClient)this).GetFuturesSymbolsOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFuturesSymbolsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesSymbol[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesSymbol[]>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedFuturesSymbol[]>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedFuturesSymbol[]>(Exchange, symbolInfoResult.Error!);
 
             var result = await ExchangeData.GetActiveSymbolsAsync(ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedFuturesSymbol[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFuturesSymbol[]>(result);
 
             // Quanto not supported as it doesn't currently fit in the response models
             var data = result.Data.Where(x => x.SymbolType != SymbolType.Spot && !x.IsQuanto);
@@ -1170,8 +1142,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 data = data.Where(x => request.TradingMode.Value.IsInverse() ? x.IsInverse : !x.IsInverse);
             }
             
-            var response = result.AsExchangeResult<SharedFuturesSymbol[]>(Exchange, request.TradingMode == null ? SupportedTradingModes : new[] { request.TradingMode.Value }, 
-                data.Select(s => new SharedFuturesSymbol(
+            var response = HttpResult.Ok(result, data.Select(s => new SharedFuturesSymbol(
                     s.SymbolType == SymbolType.PerpetualContract ? 
                             (s.IsInverse ? TradingMode.PerpetualInverse : TradingMode.PerpetualLinear): 
                             (s.IsInverse ? TradingMode.DeliveryInverse : TradingMode.DeliveryLinear),
@@ -1188,23 +1159,23 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 DeliveryTime = s.SettleTime
             }).ToArray());
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicFuturesId, response.Data);
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicFuturesId, response.Data!);
             return response;
         }
 
-        async Task<ExchangeResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)
+        async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)
         {
             if (!ExchangeSymbolCache.HasCached(_topicFuturesId))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<SharedSymbol[]>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<SharedSymbol[]>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<SharedSymbol[]>(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicFuturesId, baseAsset));
+            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicFuturesId, baseAsset));
         }
 
-        async Task<ExchangeResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(SharedSymbol symbol)
+        async Task<ExchangeCallResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(SharedSymbol symbol)
         {
             if (symbol.TradingMode == TradingMode.Spot)
                 throw new ArgumentException(nameof(symbol), "Spot symbols not allowed");
@@ -1212,44 +1183,44 @@ namespace BitMEX.Net.Clients.ExchangeApi
             if (!ExchangeSymbolCache.HasCached(_topicFuturesId))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<bool>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, symbol));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, symbol));
         }
 
-        async Task<ExchangeResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(string symbolName)
+        async Task<ExchangeCallResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(string symbolName)
         {
             if (!ExchangeSymbolCache.HasCached(_topicFuturesId))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<bool>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, symbolName));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, symbolName));
         }
         #endregion
 
         #region Futures Ticker client
 
-        GetTickerOptions IFuturesTickerRestClient.GetFuturesTickerOptions { get; } = new GetTickerOptions();
-        async Task<ExchangeWebResult<SharedFuturesTicker>> IFuturesTickerRestClient.GetFuturesTickerAsync(GetTickerRequest request, CancellationToken ct)
+        GetFuturesTickerOptions IFuturesTickerRestClient.GetFuturesTickerOptions { get; } = new GetFuturesTickerOptions(_exchangeName);
+        async Task<HttpResult<SharedFuturesTicker>> IFuturesTickerRestClient.GetFuturesTickerAsync(GetTickerRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTickerRestClient)this).GetFuturesTickerOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFuturesTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesTicker>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesTicker>(Exchange, validationError);
 
             var resultTicker = await ExchangeData.GetSymbolsAsync(request.Symbol!.GetSymbol(FormatSymbol), ct: ct).ConfigureAwait(false);
-            if (!resultTicker)
-                return resultTicker.AsExchangeResult<SharedFuturesTicker>(Exchange, null, default);
+            if (!resultTicker.Success)
+                return HttpResult.Fail<SharedFuturesTicker>(resultTicker);
 
             var symbol = resultTicker.Data.SingleOrDefault();
             if (symbol == null)
-                return resultTicker.AsExchangeError<SharedFuturesTicker>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                return HttpResult.Fail<SharedFuturesTicker>(resultTicker, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-            return resultTicker.AsExchangeResult(Exchange, request.Symbol!.TradingMode, 
+            return HttpResult.Ok(resultTicker, 
                 new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, symbol.Symbol), symbol.Symbol, symbol.LastPrice, symbol.HighPrice, symbol.LowPrice, symbol.Volume, symbol.LastChangePercentage)
             {
                 MarkPrice = symbol.MarkPrice,
@@ -1258,16 +1229,16 @@ namespace BitMEX.Net.Clients.ExchangeApi
             });
         }
 
-        GetTickersOptions IFuturesTickerRestClient.GetFuturesTickersOptions { get; } = new GetTickersOptions();
-        async Task<ExchangeWebResult<SharedFuturesTicker[]>> IFuturesTickerRestClient.GetFuturesTickersAsync(GetTickersRequest request, CancellationToken ct)
+        GetFuturesTickersOptions IFuturesTickerRestClient.GetFuturesTickersOptions { get; } = new GetFuturesTickersOptions(_exchangeName);
+        async Task<HttpResult<SharedFuturesTicker[]>> IFuturesTickerRestClient.GetFuturesTickersAsync(GetTickersRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTickerRestClient)this).GetFuturesTickersOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFuturesTickersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesTicker[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesTicker[]>(Exchange, validationError);
 
             var resultTickers = await ExchangeData.GetActiveSymbolsAsync(ct: ct).ConfigureAwait(false);
-            if (!resultTickers)
-                return resultTickers.AsExchangeResult<SharedFuturesTicker[]>(Exchange, null, default);
+            if (!resultTickers.Success)
+                return HttpResult.Fail<SharedFuturesTicker[]>(resultTickers);
 
             var data = resultTickers.Data.Where(x => x.SymbolType != SymbolType.Spot);
             if (request.TradingMode != null)
@@ -1276,7 +1247,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 data = data.Where(x => request.TradingMode.Value.IsInverse() ? x.IsInverse : !x.IsInverse);
             }
 
-            return resultTickers.AsExchangeResult<SharedFuturesTicker[]>(Exchange, request.TradingMode == null ? SupportedTradingModes : new[] { request.TradingMode.Value }, data.Select(x =>
+            return HttpResult.Ok(resultTickers, data.Select(x =>
             {
                 var markPrice = resultTickers.Data.Single(p => p.Symbol == x.Symbol);
                 return new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), x.Symbol, x.LastPrice, x.HighPrice, x.LowPrice, x.Volume, x.LastChangePercentage)
@@ -1293,59 +1264,59 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Leverage client
         SharedLeverageSettingMode ILeverageRestClient.LeverageSettingType => SharedLeverageSettingMode.PerSymbol;
 
-        EndpointOptions<GetLeverageRequest> ILeverageRestClient.GetLeverageOptions { get; } = new EndpointOptions<GetLeverageRequest>(true);
-        async Task<ExchangeWebResult<SharedLeverage>> ILeverageRestClient.GetLeverageAsync(GetLeverageRequest request, CancellationToken ct)
+        GetLeverageOptions ILeverageRestClient.GetLeverageOptions { get; } = new GetLeverageOptions(_exchangeName, true);
+        async Task<HttpResult<SharedLeverage>> ILeverageRestClient.GetLeverageAsync(GetLeverageRequest request, CancellationToken ct)
         {
-            var validationError = ((ILeverageRestClient)this).GetLeverageOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetLeverageOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedLeverage>(Exchange, validationError);
+                return HttpResult.Fail<SharedLeverage>(Exchange, validationError);
 
             var result = await Trading.GetPositionsAsync(filter: new Dictionary<string, object>{
                 { "symbol", request.Symbol!.GetSymbol(FormatSymbol) }
             },
             columns: new[] { "leverage" },
             ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedLeverage>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedLeverage>(result);
 
             if (!result.Data.Any())
-                return result.AsExchangeError<SharedLeverage>(Exchange, new ServerError(new ErrorInfo(ErrorType.NoPosition, "Position not found")));
+                return HttpResult.Fail<SharedLeverage>(result, new ServerError(new ErrorInfo(ErrorType.NoPosition, "Position not found")));
 
             var position = result.Data.First();
-            return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedLeverage(position.Leverage ?? 0)
+            return HttpResult.Ok(result, new SharedLeverage(position.Leverage ?? 0)
             {
                 MarginMode = position.CrossMargin ? SharedMarginMode.Cross : SharedMarginMode.Isolated
             });
         }
 
-        SetLeverageOptions ILeverageRestClient.SetLeverageOptions { get; } = new SetLeverageOptions()
+        SetLeverageOptions ILeverageRestClient.SetLeverageOptions { get; } = new SetLeverageOptions(_exchangeName)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
                 new ParameterDescription(nameof(SetLeverageRequest.MarginMode), typeof(SharedMarginMode), "Margin mode to change leverage for", SharedMarginMode.Isolated)
             }
         };
-        async Task<ExchangeWebResult<SharedLeverage>> ILeverageRestClient.SetLeverageAsync(SetLeverageRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedLeverage>> ILeverageRestClient.SetLeverageAsync(SetLeverageRequest request, CancellationToken ct)
         {
-            var validationError = ((ILeverageRestClient)this).SetLeverageOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SetLeverageOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedLeverage>(Exchange, validationError);
+                return HttpResult.Fail<SharedLeverage>(Exchange, validationError);
 
             if (request.MarginMode == SharedMarginMode.Isolated)
             {
                 var result = await Trading.SetIsolatedMarginLeverageAsync(symbol: request.Symbol!.GetSymbol(FormatSymbol), request.Leverage, ct: ct).ConfigureAwait(false);
-                if (!result)
-                    return result.AsExchangeResult<SharedLeverage>(Exchange, null, default);
+                if (!result.Success)
+                    return HttpResult.Fail<SharedLeverage>(result);
 
-                return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedLeverage(result.Data.Leverage ?? 0) { MarginMode = request.MarginMode });
+                return HttpResult.Ok(result, new SharedLeverage(result.Data.Leverage ?? 0) { MarginMode = request.MarginMode });
             }
             else
             {
                 var result = await Trading.SetCrossMarginLeverageAsync(symbol: request.Symbol!.GetSymbol(FormatSymbol), request.Leverage, ct: ct).ConfigureAwait(false);
-                if (!result)
-                    return result.AsExchangeResult<SharedLeverage>(Exchange, null, default);
+                if (!result.Success)
+                    return HttpResult.Fail<SharedLeverage>(result);
 
-                return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedLeverage(result.Data.Leverage ?? 0) { MarginMode = request.MarginMode });
+                return HttpResult.Ok(result, new SharedLeverage(result.Data.Leverage ?? 0) { MarginMode = request.MarginMode });
             }
 
         }
@@ -1353,24 +1324,24 @@ namespace BitMEX.Net.Clients.ExchangeApi
 
         #region Open Interest client
 
-        EndpointOptions<GetOpenInterestRequest> IOpenInterestRestClient.GetOpenInterestOptions { get; } = new EndpointOptions<GetOpenInterestRequest>(true);
-        async Task<ExchangeWebResult<SharedOpenInterest>> IOpenInterestRestClient.GetOpenInterestAsync(GetOpenInterestRequest request, CancellationToken ct)
+        GetOpenInterestOptions IOpenInterestRestClient.GetOpenInterestOptions { get; } = new GetOpenInterestOptions(_exchangeName, true);
+        async Task<HttpResult<SharedOpenInterest>> IOpenInterestRestClient.GetOpenInterestAsync(GetOpenInterestRequest request, CancellationToken ct)
         {
-            var validationError = ((IOpenInterestRestClient)this).GetOpenInterestOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetOpenInterestOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedOpenInterest>(Exchange, validationError);
+                return HttpResult.Fail<SharedOpenInterest>(Exchange, validationError);
 
             var result = await ExchangeData.GetSymbolsAsync(filter: new Dictionary<string, object>{
                 { "symbol", request.Symbol!.GetSymbol(FormatSymbol) }
             }, columns: ["openInterest"], ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedOpenInterest>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedOpenInterest>(result);
 
             var symbol = result.Data.SingleOrDefault();
             if (symbol == null)
-                return result.AsExchangeError<SharedOpenInterest>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                return HttpResult.Fail<SharedOpenInterest>(result, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-            return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedOpenInterest(symbol.OpenInterest ?? 0));
+            return HttpResult.Ok(result, new SharedOpenInterest(symbol.OpenInterest ?? 0));
         }
 
         #endregion
@@ -1390,19 +1361,12 @@ namespace BitMEX.Net.Clients.ExchangeApi
 
         string IFuturesOrderRestClient.GenerateClientOrderId() => ExchangeHelpers.RandomString(32);
 
-        PlaceFuturesOrderOptions IFuturesOrderRestClient.PlaceFuturesOrderOptions { get; } = new PlaceFuturesOrderOptions(false);
-        async Task<ExchangeWebResult<SharedId>> IFuturesOrderRestClient.PlaceFuturesOrderAsync(PlaceFuturesOrderRequest request, CancellationToken ct)
+        PlaceFuturesOrderOptions IFuturesOrderRestClient.PlaceFuturesOrderOptions { get; } = new PlaceFuturesOrderOptions(_exchangeName, false);
+        async Task<HttpResult<SharedId>> IFuturesOrderRestClient.PlaceFuturesOrderAsync(PlaceFuturesOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).PlaceFuturesOrderOptions.ValidateRequest(
-                Exchange,
-                request,
-                request.Symbol!.TradingMode,
-                SupportedTradingModes,
-                ((IFuturesOrderRestClient)this).FuturesSupportedOrderTypes,
-                ((IFuturesOrderRestClient)this).FuturesSupportedTimeInForce,
-                ((IFuturesOrderRestClient)this).FuturesSupportedOrderQuantity);
+            var validationError = SharedClient.PlaceFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var result = await Trading.PlaceOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
@@ -1415,18 +1379,18 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 clientOrderId: request.ClientOrderId,
                 ct: ct).ConfigureAwait(false);
 
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
-            return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedId(result.Data.OrderId));
+            return HttpResult.Ok(result, new SharedId(result.Data.OrderId));
         }
 
-        EndpointOptions<GetOrderRequest> IFuturesOrderRestClient.GetFuturesOrderOptions { get; } = new EndpointOptions<GetOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedFuturesOrder>> IFuturesOrderRestClient.GetFuturesOrderAsync(GetOrderRequest request, CancellationToken ct)
+        GetFuturesOrderOptions IFuturesOrderRestClient.GetFuturesOrderOptions { get; } = new GetFuturesOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedFuturesOrder>> IFuturesOrderRestClient.GetFuturesOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetFuturesOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesOrder>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesOrder>(Exchange, validationError);
 
             var orders = await Trading.GetOrdersAsync(request.Symbol!.GetSymbol(FormatSymbol),
                 filter: new Dictionary<string, object>
@@ -1434,14 +1398,14 @@ namespace BitMEX.Net.Clients.ExchangeApi
                     { "orderID", request.OrderId }
                 },
                 ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return orders.AsExchangeResult<SharedFuturesOrder>(Exchange, null, default);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedFuturesOrder>(orders);
 
             var order = orders.Data.SingleOrDefault();
             if (order == null)
-                return orders.AsExchangeError<SharedFuturesOrder>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
+                return HttpResult.Fail<SharedFuturesOrder>(orders, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
 
-            return orders.AsExchangeResult(Exchange, TradingMode.Spot, new SharedFuturesOrder(
+            return HttpResult.Ok(orders, new SharedFuturesOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicFuturesId, order.Symbol),
                 order.Symbol,
                 order.OrderId,
@@ -1464,12 +1428,12 @@ namespace BitMEX.Net.Clients.ExchangeApi
             });
         }
 
-        EndpointOptions<GetOpenOrdersRequest> IFuturesOrderRestClient.GetOpenFuturesOrdersOptions { get; } = new EndpointOptions<GetOpenOrdersRequest>(true);
-        async Task<ExchangeWebResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetOpenFuturesOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
+        GetOpenFuturesOrdersOptions IFuturesOrderRestClient.GetOpenFuturesOrdersOptions { get; } = new GetOpenFuturesOrdersOptions(_exchangeName, true);
+        async Task<HttpResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetOpenFuturesOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetOpenFuturesOrdersOptions.ValidateRequest(Exchange, request, request.Symbol?.TradingMode ?? request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetOpenFuturesOrdersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesOrder[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesOrder[]>(Exchange, validationError);
 
             var symbol = request.Symbol?.GetSymbol(FormatSymbol);
             var orders = await Trading.GetOrdersAsync(symbol,
@@ -1478,11 +1442,11 @@ namespace BitMEX.Net.Clients.ExchangeApi
                     { "ordStatus", new [] { "New", "PartiallyFilled" } }
                 },
                 ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return orders.AsExchangeResult<SharedFuturesOrder[]>(Exchange, null, default);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedFuturesOrder[]>(orders);
 
             var data = orders.Data.Where(x => BitMEXUtils.GetSymbolType(x.Symbol) != SymbolType.Spot);
-            return orders.AsExchangeResult<SharedFuturesOrder[]>(Exchange, SupportedTradingModes.Where(x => x != TradingMode.Spot).ToArray(), data.Select(x => new SharedFuturesOrder(
+            return HttpResult.Ok(orders, data.Select(x => new SharedFuturesOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol),
                 x.Symbol,
                 x.OrderId,
@@ -1505,12 +1469,12 @@ namespace BitMEX.Net.Clients.ExchangeApi
             }).ToArray());
         }
 
-        GetClosedOrdersOptions IFuturesOrderRestClient.GetClosedFuturesOrdersOptions { get; } = new GetClosedOrdersOptions(true, true, true, 1000);
-        async Task<ExchangeWebResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetClosedFuturesOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageRequest, CancellationToken ct)
+        GetFuturesClosedOrdersOptions IFuturesOrderRestClient.GetClosedFuturesOrdersOptions { get; } = new GetFuturesClosedOrdersOptions(_exchangeName, true, true, true, 1000);
+        async Task<HttpResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetClosedFuturesOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetClosedFuturesOrdersOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetClosedFuturesOrdersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesOrder[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesOrder[]>(Exchange, validationError);
 
             var direction = request.Direction ?? DataDirection.Descending;
             var limit = request.Limit ?? 500;
@@ -1528,8 +1492,8 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 offset: pageParams.Offset,
                 reverse: direction == DataDirection.Descending,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedFuturesOrder[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFuturesOrder[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                 () => Pagination.NextPageFromOffset(pageParams, result.Data.Length),
@@ -1539,10 +1503,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 request.EndTime ?? DateTime.UtcNow,
                 pageParams);
 
-            return result.AsExchangeResult(
-                       Exchange,
-                       SupportedTradingModes.Where(x => x != TradingMode.Spot).ToArray(),
-                       ExchangeHelpers.ApplyFilter(result.Data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
                        .Select(x => 
                            new SharedFuturesOrder(
                                 ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), 
@@ -1568,16 +1529,16 @@ namespace BitMEX.Net.Clients.ExchangeApi
                        .ToArray(), nextPageRequest);
         }
 
-        EndpointOptions<GetOrderTradesRequest> IFuturesOrderRestClient.GetFuturesOrderTradesOptions { get; } = new EndpointOptions<GetOrderTradesRequest>(true);
-        async Task<ExchangeWebResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
+        GetFuturesOrderTradesOptions IFuturesOrderRestClient.GetFuturesOrderTradesOptions { get; } = new GetFuturesOrderTradesOptions(_exchangeName, true);
+        async Task<HttpResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetFuturesOrderTradesOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFuturesOrderTradesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, symbolInfoResult.Error!);
 
             var trades = await Trading.GetUserTradesAsync(symbol: request.Symbol!.GetSymbol(FormatSymbol),
                 filter: new Dictionary<string, object>
@@ -1585,10 +1546,10 @@ namespace BitMEX.Net.Clients.ExchangeApi
                     { "orderID", request.OrderId }
                 },
                 ct: ct).ConfigureAwait(false);
-            if (!trades)
-                return trades.AsExchangeResult<SharedUserTrade[]>(Exchange, null, default);
+            if (!trades.Success)
+                return HttpResult.Fail<SharedUserTrade[]>(trades);
 
-            return trades.AsExchangeResult<SharedUserTrade[]>(Exchange, request.Symbol!.TradingMode, trades.Data.Select(x => new SharedUserTrade(
+            return HttpResult.Ok(trades, trades.Data.Select(x => new SharedUserTrade(
                 ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), 
                 x.Symbol,
                 x.OrderId,
@@ -1604,16 +1565,16 @@ namespace BitMEX.Net.Clients.ExchangeApi
             }).ToArray());
         }
 
-        GetUserTradesOptions IFuturesOrderRestClient.GetFuturesUserTradesOptions { get; } = new GetUserTradesOptions(true, true, true, 1000);
-        async Task<ExchangeWebResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        GetFuturesUserTradesOptions IFuturesOrderRestClient.GetFuturesUserTradesOptions { get; } = new GetFuturesUserTradesOptions(_exchangeName, true, true, true, 1000);
+        async Task<HttpResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetFuturesUserTradesOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFuturesUserTradesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, symbolInfoResult.Error!);
 
             var direction = request.Direction ?? DataDirection.Descending;
             var limit = request.Limit ?? 500;
@@ -1628,8 +1589,8 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 reverse: direction == DataDirection.Descending,
                 ct: ct
                 ).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedUserTrade[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedUserTrade[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                 () => Pagination.NextPageFromOffset(pageParams, result.Data.Length),
@@ -1639,10 +1600,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 request.EndTime ?? DateTime.UtcNow,
                 pageParams);
 
-            return result.AsExchangeResult(
-                       Exchange,
-                       SupportedTradingModes.Where(x => x != TradingMode.Spot).ToArray(),
-                       ExchangeHelpers.ApplyFilter(result.Data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
                        .Select(x => 
                             new SharedUserTrade(
                                 ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), 
@@ -1661,39 +1619,39 @@ namespace BitMEX.Net.Clients.ExchangeApi
                        .ToArray(), nextPageRequest);
         }
 
-        EndpointOptions<CancelOrderRequest> IFuturesOrderRestClient.CancelFuturesOrderOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> IFuturesOrderRestClient.CancelFuturesOrderAsync(CancelOrderRequest request, CancellationToken ct)
+        CancelFuturesOrderOptions IFuturesOrderRestClient.CancelFuturesOrderOptions { get; } = new CancelFuturesOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedId>> IFuturesOrderRestClient.CancelFuturesOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).CancelFuturesOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.CancelFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var order = await Trading.CancelOrderAsync(request.OrderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return order.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedId(request.OrderId));
+            return HttpResult.Ok(order, new SharedId(request.OrderId));
         }
 
-        EndpointOptions<GetPositionsRequest> IFuturesOrderRestClient.GetPositionsOptions { get; } = new EndpointOptions<GetPositionsRequest>(true);
-        async Task<ExchangeWebResult<SharedPosition[]>> IFuturesOrderRestClient.GetPositionsAsync(GetPositionsRequest request, CancellationToken ct)
+        GetPositionsOptions IFuturesOrderRestClient.GetPositionsOptions { get; } = new GetPositionsOptions(_exchangeName, true);
+        async Task<HttpResult<SharedPosition[]>> IFuturesOrderRestClient.GetPositionsAsync(GetPositionsRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetPositionsOptions.ValidateRequest(Exchange, request, request.Symbol?.TradingMode ?? request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetPositionsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedPosition[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedPosition[]>(Exchange, validationError);
 
             var result = await Trading.GetPositionsAsync(filter: request.Symbol == null ? null : new Dictionary<string, object>{
                 { "symbol", request.Symbol!.GetSymbol(FormatSymbol) }
             }, ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedPosition[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedPosition[]>(result);
 
             IEnumerable<BitMEXPosition> data = result.Data;
             if (request.TradingMode != null)
                 data = data.Where(x => request.TradingMode.Value.IsPerpetual() ? BitMEXUtils.GetSymbolType(x.Symbol) == SymbolType.PerpetualContract : BitMEXUtils.GetSymbolType(x.Symbol) == SymbolType.Futures);
             
             var resultTypes = request.Symbol == null && request.TradingMode == null ? SupportedTradingModes : request.Symbol != null ? new[] { request.Symbol!.TradingMode } : new[] { request.TradingMode!.Value };
-            return result.AsExchangeResult<SharedPosition[]>(Exchange, resultTypes, data.Where(x => x.Currency != null).Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), x.Symbol, Math.Abs(x.CurrentQuantity ?? 0), x.Timestamp)
+            return HttpResult.Ok(result, data.Where(x => x.Currency != null).Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), x.Symbol, Math.Abs(x.CurrentQuantity ?? 0), x.Timestamp)
             {
                 UnrealizedPnl = x.UnrealizedPnl.ToSharedAssetQuantity(x.Currency!),
                 LiquidationPrice = x.LiquidationPrice == 0 ? null : x.LiquidationPrice,
@@ -1704,18 +1662,18 @@ namespace BitMEX.Net.Clients.ExchangeApi
             }).ToArray());
         }
 
-        EndpointOptions<ClosePositionRequest> IFuturesOrderRestClient.ClosePositionOptions { get; } = new EndpointOptions<ClosePositionRequest>(true)
+        ClosePositionOptions IFuturesOrderRestClient.ClosePositionOptions { get; } = new ClosePositionOptions(_exchangeName, true)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
                 new ParameterDescription(nameof(ClosePositionRequest.PositionSide), typeof(SharedPositionSide), "The position side to close", SharedPositionSide.Long),
             }
         };
-        async Task<ExchangeWebResult<SharedId>> IFuturesOrderRestClient.ClosePositionAsync(ClosePositionRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> IFuturesOrderRestClient.ClosePositionAsync(ClosePositionRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).ClosePositionOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.ClosePositionOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol); 
             var result = await Trading.PlaceOrderAsync(
@@ -1724,26 +1682,26 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 OrderType.Market,
                 executionInstruction: ExecutionInstruction.Close,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
-            return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedId(result.Data.OrderId));
+            return HttpResult.Ok(result, new SharedId(result.Data.OrderId));
         }
 
         #endregion
 
         #region Futures Client Id Order Client
 
-        EndpointOptions<GetOrderRequest> IFuturesOrderClientIdRestClient.GetFuturesOrderByClientOrderIdOptions { get; } = new EndpointOptions<GetOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedFuturesOrder>> IFuturesOrderClientIdRestClient.GetFuturesOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
+        GetFuturesOrderByClientOrderIdOptions IFuturesOrderClientIdRestClient.GetFuturesOrderByClientOrderIdOptions { get; } = new GetFuturesOrderByClientOrderIdOptions(_exchangeName, true);
+        async Task<HttpResult<SharedFuturesOrder>> IFuturesOrderClientIdRestClient.GetFuturesOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetFuturesOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesOrder>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesOrder>(Exchange, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeWebResult<SharedFuturesOrder>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return HttpResult.Fail<SharedFuturesOrder>(Exchange, symbolInfoResult.Error!);
 
             var orders = await Trading.GetOrdersAsync(request.Symbol!.GetSymbol(FormatSymbol),
                 filter: new Dictionary<string, object>
@@ -1751,14 +1709,14 @@ namespace BitMEX.Net.Clients.ExchangeApi
                     { "clOrdID", request.OrderId }
                 },
                 ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return orders.AsExchangeResult<SharedFuturesOrder>(Exchange, null, default);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedFuturesOrder>(orders);
 
             var order = orders.Data.SingleOrDefault();
             if (order == null)
-                return orders.AsExchangeError<SharedFuturesOrder>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
+                return HttpResult.Fail<SharedFuturesOrder>(orders, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
 
-            return orders.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedFuturesOrder(
+            return HttpResult.Ok(orders, new SharedFuturesOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicFuturesId, order.Symbol),
                 order.Symbol,
                 order.OrderId,
@@ -1781,32 +1739,32 @@ namespace BitMEX.Net.Clients.ExchangeApi
             });
         }
 
-        EndpointOptions<CancelOrderRequest> IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
+        CancelFuturesOrderByClientOrderIdOptions IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdOptions { get; } = new CancelFuturesOrderByClientOrderIdOptions(_exchangeName, true);
+        async Task<HttpResult<SharedId>> IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).CancelFuturesOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.CancelFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var order = await Trading.CancelOrderAsync(clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return order.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedId(order.Data.OrderId));
+            return HttpResult.Ok(order, new SharedId(order.Data.OrderId));
         }
         #endregion
 
         #region Futures Trigger Order Client
-        PlaceFuturesTriggerOrderOptions IFuturesTriggerOrderRestClient.PlaceFuturesTriggerOrderOptions { get; } = new PlaceFuturesTriggerOrderOptions(false)
+        PlaceFuturesTriggerOrderOptions IFuturesTriggerOrderRestClient.PlaceFuturesTriggerOrderOptions { get; } = new PlaceFuturesTriggerOrderOptions(_exchangeName, false)
         {
         };
 
-        async Task<ExchangeWebResult<SharedId>> IFuturesTriggerOrderRestClient.PlaceFuturesTriggerOrderAsync(PlaceFuturesTriggerOrderRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> IFuturesTriggerOrderRestClient.PlaceFuturesTriggerOrderAsync(PlaceFuturesTriggerOrderRequest request, CancellationToken ct)
         {
             var side = GetTriggerOrderSide(request);
-            var validationError = ((IFuturesTriggerOrderRestClient)this).PlaceFuturesTriggerOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes, side == OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell, ((IFuturesOrderRestClient)this).FuturesSupportedOrderQuantity);
+            var validationError = SharedClient.PlaceFuturesTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var result = await Trading.PlaceOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
@@ -1819,22 +1777,22 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 timeInForce: GetTimeInForce(request.TimeInForce),
                 clientOrderId: request.ClientOrderId,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
             // Return
-            return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedId(result.Data.OrderId.ToString()));
+            return HttpResult.Ok(result, new SharedId(result.Data.OrderId.ToString()));
         }
 
-        EndpointOptions<GetOrderRequest> IFuturesTriggerOrderRestClient.GetFuturesTriggerOrderOptions { get; } = new EndpointOptions<GetOrderRequest>(true)
+        GetFuturesTriggerOrderOptions IFuturesTriggerOrderRestClient.GetFuturesTriggerOrderOptions { get; } = new GetFuturesTriggerOrderOptions(_exchangeName, true)
         {
             RequestNotes = "Only pending trigger orders can be requested, executed trigger orders are not available in the API"
         };
-        async Task<ExchangeWebResult<SharedFuturesTriggerOrder>> IFuturesTriggerOrderRestClient.GetFuturesTriggerOrderAsync(GetOrderRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedFuturesTriggerOrder>> IFuturesTriggerOrderRestClient.GetFuturesTriggerOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTriggerOrderRestClient)this).GetFuturesTriggerOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFuturesTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesTriggerOrder>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesTriggerOrder>(Exchange, validationError);
 
             var orders = await Trading.GetOrdersAsync(request.Symbol!.GetSymbol(FormatSymbol),
                 filter: new Dictionary<string, object>
@@ -1842,14 +1800,14 @@ namespace BitMEX.Net.Clients.ExchangeApi
                     { "orderID", request.OrderId }
                 },
                 ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return orders.AsExchangeResult<SharedFuturesTriggerOrder>(Exchange, null, default);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedFuturesTriggerOrder>(orders);
 
             var order = orders.Data.SingleOrDefault();
             if (order == null)
-                return orders.AsExchangeError<SharedFuturesTriggerOrder>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
+                return HttpResult.Fail<SharedFuturesTriggerOrder>(orders, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
 
-            return orders.AsExchangeResult(Exchange, TradingMode.Spot, new SharedFuturesTriggerOrder(
+            return HttpResult.Ok(orders, new SharedFuturesTriggerOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicFuturesId, order.Symbol),
                 order.Symbol,
                 order.OrderId,
@@ -1870,20 +1828,20 @@ namespace BitMEX.Net.Clients.ExchangeApi
             });
         }
 
-        EndpointOptions<CancelOrderRequest> IFuturesTriggerOrderRestClient.CancelFuturesTriggerOrderOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> IFuturesTriggerOrderRestClient.CancelFuturesTriggerOrderAsync(CancelOrderRequest request, CancellationToken ct)
+        CancelFuturesTriggerOrderOptions IFuturesTriggerOrderRestClient.CancelFuturesTriggerOrderOptions { get; } = new CancelFuturesTriggerOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedId>> IFuturesTriggerOrderRestClient.CancelFuturesTriggerOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTriggerOrderRestClient)this).CancelFuturesTriggerOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.CancelFuturesTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var order = await Trading.CancelOrderAsync(
                 request.OrderId,
                 ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return order.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(request.OrderId));
+            return HttpResult.Ok(order, new SharedId(request.OrderId));
         }
 
         private OrderType GetTriggerOrderType(PlaceSpotTriggerOrderRequest request)
@@ -1961,13 +1919,13 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #endregion
 
         #region Spot Trigger Order Client
-        PlaceSpotTriggerOrderOptions ISpotTriggerOrderRestClient.PlaceSpotTriggerOrderOptions { get; } = new PlaceSpotTriggerOrderOptions(false);
+        PlaceSpotTriggerOrderOptions ISpotTriggerOrderRestClient.PlaceSpotTriggerOrderOptions { get; } = new PlaceSpotTriggerOrderOptions(_exchangeName, false);
 
-        async Task<ExchangeWebResult<SharedId>> ISpotTriggerOrderRestClient.PlaceSpotTriggerOrderAsync(PlaceSpotTriggerOrderRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> ISpotTriggerOrderRestClient.PlaceSpotTriggerOrderAsync(PlaceSpotTriggerOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotTriggerOrderRestClient)this).PlaceSpotTriggerOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes, ((ISpotOrderRestClient)this).SpotSupportedOrderQuantity);
+            var validationError = SharedClient.PlaceSpotTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var result = await Trading.PlaceOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
@@ -1979,22 +1937,22 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 stopPrice: request.TriggerPrice,
                 timeInForce: GetTimeInForce(request.TimeInForce),
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
             // Return
-            return result.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(result.Data.OrderId.ToString()));
+            return HttpResult.Ok(result, new SharedId(result.Data.OrderId.ToString()));
         }
 
-        EndpointOptions<GetOrderRequest> ISpotTriggerOrderRestClient.GetSpotTriggerOrderOptions { get; } = new EndpointOptions<GetOrderRequest>(true)
+        GetSpotTriggerOrderOptions ISpotTriggerOrderRestClient.GetSpotTriggerOrderOptions { get; } = new GetSpotTriggerOrderOptions(_exchangeName, true)
         {
             RequestNotes = "Only pending trigger orders can be requested, executed trigger orders are not available in the API"
         };
-        async Task<ExchangeWebResult<SharedSpotTriggerOrder>> ISpotTriggerOrderRestClient.GetSpotTriggerOrderAsync(GetOrderRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedSpotTriggerOrder>> ISpotTriggerOrderRestClient.GetSpotTriggerOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotTriggerOrderRestClient)this).GetSpotTriggerOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotTriggerOrder>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotTriggerOrder>(Exchange, validationError);
 
             var orders = await Trading.GetOrdersAsync(request.Symbol!.GetSymbol(FormatSymbol),
                 filter: new Dictionary<string, object>
@@ -2002,14 +1960,14 @@ namespace BitMEX.Net.Clients.ExchangeApi
                     { "orderID", request.OrderId }
                 },
                 ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return orders.AsExchangeResult<SharedSpotTriggerOrder>(Exchange, null, default);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedSpotTriggerOrder>(orders);
 
             var order = orders.Data.SingleOrDefault();
             if (order == null)
-                return orders.AsExchangeError<SharedSpotTriggerOrder>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
+                return HttpResult.Fail<SharedSpotTriggerOrder>(orders, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
 
-            return orders.AsExchangeResult(Exchange, TradingMode.Spot, new SharedSpotTriggerOrder(
+            return HttpResult.Ok(orders, new SharedSpotTriggerOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicSpotId, order.Symbol),
                 order.Symbol,
                 order.OrderId,
@@ -2044,25 +2002,25 @@ namespace BitMEX.Net.Clients.ExchangeApi
             return SharedTriggerOrderStatus.Unknown;
         }
 
-        EndpointOptions<CancelOrderRequest> ISpotTriggerOrderRestClient.CancelSpotTriggerOrderOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> ISpotTriggerOrderRestClient.CancelSpotTriggerOrderAsync(CancelOrderRequest request, CancellationToken ct)
+        CancelSpotTriggerOrderOptions ISpotTriggerOrderRestClient.CancelSpotTriggerOrderOptions { get; } = new CancelSpotTriggerOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedId>> ISpotTriggerOrderRestClient.CancelSpotTriggerOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotTriggerOrderRestClient)this).CancelSpotTriggerOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.CancelSpotTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var order = await Trading.CancelOrderAsync(
                 request.OrderId,
                 ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return order.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(request.OrderId));
+            return HttpResult.Ok(order, new SharedId(request.OrderId));
         }
         #endregion
 
         #region Tp/SL Client
-        EndpointOptions<SetTpSlRequest> IFuturesTpSlRestClient.SetFuturesTpSlOptions { get; } = new EndpointOptions<SetTpSlRequest>(true)
+        SetFuturesTpSlOptions IFuturesTpSlRestClient.SetFuturesTpSlOptions { get; } = new SetFuturesTpSlOptions(_exchangeName, true)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
@@ -2070,11 +2028,11 @@ namespace BitMEX.Net.Clients.ExchangeApi
             }
         };
 
-        async Task<ExchangeWebResult<SharedId>> IFuturesTpSlRestClient.SetFuturesTpSlAsync(SetTpSlRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> IFuturesTpSlRestClient.SetFuturesTpSlAsync(SetTpSlRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTpSlRestClient)this).SetFuturesTpSlOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SetFuturesTpSlOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var result = await Trading.PlaceOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
@@ -2084,14 +2042,14 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 executionInstruction: ExecutionInstruction.Close,
                 ct: ct).ConfigureAwait(false);
 
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
             // Return
-            return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedId(result.Data.OrderId.ToString()));
+            return HttpResult.Ok(result, new SharedId(result.Data.OrderId.ToString()));
         }
 
-        EndpointOptions<CancelTpSlRequest> IFuturesTpSlRestClient.CancelFuturesTpSlOptions { get; } = new EndpointOptions<CancelTpSlRequest>(true)
+        CancelFuturesTpSlOptions IFuturesTpSlRestClient.CancelFuturesTpSlOptions { get; } = new CancelFuturesTpSlOptions(_exchangeName, true)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
@@ -2099,20 +2057,20 @@ namespace BitMEX.Net.Clients.ExchangeApi
             }
         };
 
-        async Task<ExchangeWebResult<bool>> IFuturesTpSlRestClient.CancelFuturesTpSlAsync(CancelTpSlRequest request, CancellationToken ct)
+        async Task<HttpResult<bool>> IFuturesTpSlRestClient.CancelFuturesTpSlAsync(CancelTpSlRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTpSlRestClient)this).CancelFuturesTpSlOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.CancelFuturesTpSlOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<bool>(Exchange, validationError);
+                return HttpResult.Fail<bool>(Exchange, validationError);
 
             var result = await Trading.CancelOrderAsync(
                 orderId: request.OrderId!,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<bool>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<bool>(result);
 
             // Return
-            return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, true);
+            return HttpResult.Ok(result, true);
         }
 
         #endregion

--- a/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiShared.cs
+++ b/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiShared.cs
@@ -24,7 +24,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
-        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(BitMEXExchange.Metadata, this);
 
 
         #region Asset client
@@ -441,7 +441,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 return HttpResult.Fail<SharedBookTicker>(resultTicker, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
             return HttpResult.Ok(resultTicker, new SharedBookTicker(
-                ExchangeSymbolCache.ParseSymbol(request.Symbol!.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, resultTicker.Data[0].Symbol),
+                ExchangeSymbolCache.ParseSymbol(request.Symbol!.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, EnvironmentName, null, resultTicker.Data[0].Symbol),
                 resultTicker.Data[0].Symbol,
                 resultTicker.Data[0].BestAskPrice,
                 resultTicker.Data[0].BestAskQuantity.ToSharedSymbolQuantity(resultTicker.Data[0].Symbol) ?? 0,
@@ -584,20 +584,20 @@ namespace BitMEX.Net.Clients.ExchangeApi
                     PriceStep = s.PriceStep
                 }).ToArray());
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicSpotId, response.Data!);
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicSpotId, EnvironmentName, null, response.Data!);
             return response;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)
         {
-            if (!ExchangeSymbolCache.HasCached(_topicSpotId))
+            if (!ExchangeSymbolCache.HasCached(_topicSpotId, EnvironmentName, null))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<SharedSymbol[]>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicSpotId, baseAsset));
+            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicSpotId, EnvironmentName, null, baseAsset));
         }
 
         async Task<ExchangeCallResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(SharedSymbol symbol)
@@ -605,26 +605,26 @@ namespace BitMEX.Net.Clients.ExchangeApi
             if (symbol.TradingMode != TradingMode.Spot)
                 throw new ArgumentException(nameof(symbol), "Only Spot symbols allowed");
 
-            if (!ExchangeSymbolCache.HasCached(_topicSpotId))
+            if (!ExchangeSymbolCache.HasCached(_topicSpotId, EnvironmentName, null))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, symbol));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, EnvironmentName, null, symbol));
         }
 
         async Task<ExchangeCallResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(string symbolName)
         {
-            if (!ExchangeSymbolCache.HasCached(_topicSpotId))
+            if (!ExchangeSymbolCache.HasCached(_topicSpotId, EnvironmentName, null))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, symbolName));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, EnvironmentName, null, symbolName));
         }
         #endregion
 
@@ -650,7 +650,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 return HttpResult.Fail<SharedSpotTicker>(result, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
             return HttpResult.Ok(result, new SharedSpotTicker(
-                ExchangeSymbolCache.ParseSymbol(_topicSpotId, symbol.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, symbol.Symbol),
                 symbol.Symbol,
                 symbol.LastPrice,
                 symbol.HighPrice,
@@ -680,7 +680,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
 
             return HttpResult.Ok(result, result.Data.Where(x => x.SymbolType == SymbolType.Spot).Select(x =>
             new SharedSpotTicker(
-                ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, x.Symbol),
                 x.Symbol,
                 x.LastPrice,
                 x.HighPrice,
@@ -760,7 +760,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 return HttpResult.Fail<SharedSpotOrder>(orders, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
 
             return HttpResult.Ok(orders, new SharedSpotOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicSpotId, order.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, order.Symbol),
                 order.Symbol,
                 order.OrderId,
                 ParseOrderType(order.OrderType, order.ExecutionInstruction),
@@ -803,7 +803,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
 
             var data = orders.Data.Where(x => BitMEXUtils.GetSymbolType(x.Symbol) == SymbolType.Spot);
             return HttpResult.Ok(orders, data.Select(x => new SharedSpotOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, x.Symbol),
                 x.Symbol,
                 x.OrderId,
                 ParseOrderType(x.OrderType, x.ExecutionInstruction),
@@ -864,7 +864,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
             return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
                        .Select(x => 
                            new SharedSpotOrder(
-                                ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), 
+                                ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, x.Symbol), 
                                 x.Symbol,
                                 x.OrderId,
                                 ParseOrderType(x.OrderType, x.ExecutionInstruction),
@@ -906,7 +906,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 return HttpResult.Fail<SharedUserTrade[]>(trades);
 
             return HttpResult.Ok(trades, trades.Data.Select(x => new SharedUserTrade(
-                ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), 
+                ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, x.Symbol), 
                 x.Symbol,
                 x.OrderId,
                 x.TradeId,
@@ -959,7 +959,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
             return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
                        .Select(x => 
                            new SharedUserTrade(
-                                ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), 
+                                ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, x.Symbol), 
                                 x.Symbol,
                                 x.OrderId,
                                 x.TradeId,
@@ -1054,7 +1054,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 return HttpResult.Fail<SharedSpotOrder>(orders, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
 
             return HttpResult.Ok(orders, new SharedSpotOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicSpotId, order.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, order.Symbol),
                 order.Symbol,
                 order.OrderId,
                 ParseOrderType(order.OrderType, order.ExecutionInstruction),
@@ -1171,20 +1171,20 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 DeliveryTime = s.SettleTime
             }).ToArray());
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicFuturesId, response.Data!);
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicFuturesId, EnvironmentName, null, response.Data!);
             return response;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)
         {
-            if (!ExchangeSymbolCache.HasCached(_topicFuturesId))
+            if (!ExchangeSymbolCache.HasCached(_topicFuturesId, EnvironmentName, null))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<SharedSymbol[]>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicFuturesId, baseAsset));
+            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicFuturesId, EnvironmentName, null, baseAsset));
         }
 
         async Task<ExchangeCallResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(SharedSymbol symbol)
@@ -1192,26 +1192,26 @@ namespace BitMEX.Net.Clients.ExchangeApi
             if (symbol.TradingMode == TradingMode.Spot)
                 throw new ArgumentException(nameof(symbol), "Spot symbols not allowed");
 
-            if (!ExchangeSymbolCache.HasCached(_topicFuturesId))
+            if (!ExchangeSymbolCache.HasCached(_topicFuturesId, EnvironmentName, null))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, symbol));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, EnvironmentName, null, symbol));
         }
 
         async Task<ExchangeCallResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(string symbolName)
         {
-            if (!ExchangeSymbolCache.HasCached(_topicFuturesId))
+            if (!ExchangeSymbolCache.HasCached(_topicFuturesId, EnvironmentName, null))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, symbolName));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, EnvironmentName, null, symbolName));
         }
         #endregion
 
@@ -1233,7 +1233,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 return HttpResult.Fail<SharedFuturesTicker>(resultTicker, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
             return HttpResult.Ok(resultTicker, 
-                new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, symbol.Symbol), symbol.Symbol, symbol.LastPrice, symbol.HighPrice, symbol.LowPrice, symbol.Volume, symbol.LastChangePercentage)
+                new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, symbol.Symbol), symbol.Symbol, symbol.LastPrice, symbol.HighPrice, symbol.LowPrice, symbol.Volume, symbol.LastChangePercentage)
             {
                 MarkPrice = symbol.MarkPrice,
                 FundingRate = symbol.FundingRate,
@@ -1262,7 +1262,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
             return HttpResult.Ok(resultTickers, data.Select(x =>
             {
                 var markPrice = resultTickers.Data.Single(p => p.Symbol == x.Symbol);
-                return new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), x.Symbol, x.LastPrice, x.HighPrice, x.LowPrice, x.Volume, x.LastChangePercentage)
+                return new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, x.Symbol), x.Symbol, x.LastPrice, x.HighPrice, x.LowPrice, x.Volume, x.LastChangePercentage)
                 {
                     MarkPrice = markPrice.MarkPrice,
                     FundingRate = markPrice.FundingRate,
@@ -1418,7 +1418,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 return HttpResult.Fail<SharedFuturesOrder>(orders, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
 
             return HttpResult.Ok(orders, new SharedFuturesOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, order.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, order.Symbol),
                 order.Symbol,
                 order.OrderId,
                 ParseOrderType(order.OrderType, order.ExecutionInstruction),
@@ -1459,7 +1459,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
 
             var data = orders.Data.Where(x => BitMEXUtils.GetSymbolType(x.Symbol) != SymbolType.Spot);
             return HttpResult.Ok(orders, data.Select(x => new SharedFuturesOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, x.Symbol),
                 x.Symbol,
                 x.OrderId,
                 ParseOrderType(x.OrderType, x.ExecutionInstruction),
@@ -1518,7 +1518,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
             return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
                        .Select(x => 
                            new SharedFuturesOrder(
-                                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), 
+                                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, x.Symbol), 
                                 x.Symbol,
                                 x.OrderId,
                                 ParseOrderType(x.OrderType, x.ExecutionInstruction),
@@ -1562,7 +1562,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 return HttpResult.Fail<SharedUserTrade[]>(trades);
 
             return HttpResult.Ok(trades, trades.Data.Select(x => new SharedUserTrade(
-                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), 
+                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, x.Symbol), 
                 x.Symbol,
                 x.OrderId,
                 x.TradeId,
@@ -1615,7 +1615,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
             return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
                        .Select(x => 
                             new SharedUserTrade(
-                                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), 
+                                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, x.Symbol), 
                                 x.Symbol,
                                 x.OrderId,
                                 x.TradeId,
@@ -1663,7 +1663,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 data = data.Where(x => request.TradingMode.Value.IsPerpetual() ? BitMEXUtils.GetSymbolType(x.Symbol) == SymbolType.PerpetualContract : BitMEXUtils.GetSymbolType(x.Symbol) == SymbolType.Futures);
             
             var resultTypes = request.Symbol == null && request.TradingMode == null ? SupportedTradingModes : request.Symbol != null ? new[] { request.Symbol!.TradingMode } : new[] { request.TradingMode!.Value };
-            return HttpResult.Ok(result, data.Where(x => x.Currency != null).Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), x.Symbol, Math.Abs(x.CurrentQuantity ?? 0), x.Timestamp)
+            return HttpResult.Ok(result, data.Where(x => x.Currency != null).Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, x.Symbol), x.Symbol, Math.Abs(x.CurrentQuantity ?? 0), x.Timestamp)
             {
                 UnrealizedPnl = x.UnrealizedPnl.ToSharedAssetQuantity(x.Currency!),
                 LiquidationPrice = x.LiquidationPrice == 0 ? null : x.LiquidationPrice,
@@ -1729,7 +1729,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 return HttpResult.Fail<SharedFuturesOrder>(orders, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
 
             return HttpResult.Ok(orders, new SharedFuturesOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, order.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, order.Symbol),
                 order.Symbol,
                 order.OrderId,
                 ParseOrderType(order.OrderType, order.ExecutionInstruction),
@@ -1820,7 +1820,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 return HttpResult.Fail<SharedFuturesTriggerOrder>(orders, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
 
             return HttpResult.Ok(orders, new SharedFuturesTriggerOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, order.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, order.Symbol),
                 order.Symbol,
                 order.OrderId,
                 order.OrderType == OrderType.StopLimit ? SharedOrderType.Limit : SharedOrderType.Market,
@@ -1980,7 +1980,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 return HttpResult.Fail<SharedSpotTriggerOrder>(orders, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
 
             return HttpResult.Ok(orders, new SharedSpotTriggerOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicSpotId, order.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, order.Symbol),
                 order.Symbol,
                 order.OrderId,
                 order.OrderType == OrderType.StopLimit ? SharedOrderType.Limit : SharedOrderType.Market,

--- a/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiShared.cs
+++ b/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiShared.cs
@@ -498,7 +498,8 @@ namespace BitMEX.Net.Clients.ExchangeApi
                                 x.Address,
                                 x.Quantity.ToSharedAssetQuantity(x.Currency) ?? 0,
                                 x.TransactionStatus == TransactionStatus.Completed,
-                                x.Timestamp)
+                                x.Timestamp,
+                                GetWithdrawalStatus(x))
                             {
                                 Network = x.Network,
                                 Tag = x.Memo,
@@ -507,6 +508,17 @@ namespace BitMEX.Net.Clients.ExchangeApi
                                 Id = x.TransactionId
                             })
                        .ToArray(), nextPageRequest);
+        }
+
+        private SharedTransferStatus GetWithdrawalStatus(BitMEXTransaction x)
+        {
+            if (x.TransactionStatus == TransactionStatus.Canceled)
+                return SharedTransferStatus.Failed;
+
+            if (x.TransactionStatus == TransactionStatus.Completed)
+                return SharedTransferStatus.Completed;
+
+            return SharedTransferStatus.Unknown;
         }
 
         #endregion

--- a/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiShared.cs
+++ b/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiShared.cs
@@ -121,6 +121,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
 
             return HttpResult.Ok(result, result.Data.Select(x => 
                 new SharedBalance(
+                    SupportedTradingModes,
                     BitMEXExchange.AssetAliases.ExchangeToCommonName(BitMEXUtils.GetAssetFromCurrency(x.Currency) ?? x.Currency),
                     x.Quantity.ToSharedAssetQuantity(x.Currency) ?? 0,
                     (x.Quantity + x.PendingCredit).ToSharedAssetQuantity(x.Currency) ?? 0)

--- a/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiTrading.cs
+++ b/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiTrading.cs
@@ -31,7 +31,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Place Order
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXOrder>> PlaceOrderAsync(
+        public async Task<HttpResult<BitMEXOrder>> PlaceOrderAsync(
             string symbol, 
             OrderSide orderSide,
             OrderType orderType,
@@ -48,25 +48,25 @@ namespace BitMEX.Net.Clients.ExchangeApi
             string? clientOrderId = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             parameters.Add("symbol", symbol);
-            parameters.AddEnum("side", orderSide);
-            parameters.AddEnum("ordType", orderType);
+            parameters.Add("side", orderSide);
+            parameters.Add("ordType", orderType);
 
-            parameters.AddOptional("orderQty", quantity);
-            parameters.AddOptional("price", price);
-            parameters.AddOptional("displayQty", displayQuantity);
-            parameters.AddOptional("stopPx", stopPrice);
-            parameters.AddOptional("clOrdID", clientOrderId);
-            parameters.AddOptional("clOrdLinkID", clientOrderLinkId);
-            parameters.AddOptional("pegOffsetValue", pegOffsetValue);
-            parameters.AddOptionalEnum("pegPriceType", pegPriceType);
-            parameters.AddOptionalEnum("timeInForce", timeInForce);
-            parameters.AddOptionalEnum("execInst", executionInstruction);
-            parameters.AddOptionalEnum("contingencyType", contingencyType);
+            parameters.Add("orderQty", quantity);
+            parameters.Add("price", price);
+            parameters.Add("displayQty", displayQuantity);
+            parameters.Add("stopPx", stopPrice);
+            parameters.Add("clOrdID", clientOrderId);
+            parameters.Add("clOrdLinkID", clientOrderLinkId);
+            parameters.Add("pegOffsetValue", pegOffsetValue);
+            parameters.Add("pegPriceType", pegPriceType);
+            parameters.Add("timeInForce", timeInForce);
+            parameters.Add("execInst", executionInstruction);
+            parameters.Add("contingencyType", contingencyType);
 
             parameters.Add("text", LibraryHelpers.GetClientReference(() => _baseClient.ClientOptions.BrokerId, _baseClient.Exchange));
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v1/order", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v1/order", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXOrder>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -75,7 +75,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Edit Order
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXOrder>> EditOrderAsync(
+        public async Task<HttpResult<BitMEXOrder>> EditOrderAsync(
             string? orderId = null,
             string? origClientOrderId = null,
             string? newClientOrderId = null,
@@ -86,17 +86,17 @@ namespace BitMEX.Net.Clients.ExchangeApi
             decimal? pegOffsetValue = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("orderID", orderId);
-            parameters.AddOptional("origClOrdID", origClientOrderId);
-            parameters.AddOptional("clOrdID", newClientOrderId);
-            parameters.AddOptional("orderQty", quantity);
-            parameters.AddOptional("leavesQty", quantityRemaining);
-            parameters.AddOptional("price", price);
-            parameters.AddOptional("stopPx", stopPrice);
-            parameters.AddOptional("pegOffsetValue", pegOffsetValue);
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
+            parameters.Add("orderID", orderId);
+            parameters.Add("origClOrdID", origClientOrderId);
+            parameters.Add("clOrdID", newClientOrderId);
+            parameters.Add("orderQty", quantity);
+            parameters.Add("leavesQty", quantityRemaining);
+            parameters.Add("price", price);
+            parameters.Add("stopPx", stopPrice);
+            parameters.Add("pegOffsetValue", pegOffsetValue);
             parameters.Add("text", LibraryHelpers.GetClientReference(() => _baseClient.ClientOptions.BrokerId, _baseClient.Exchange)); // Client reference
-            var request = _definitions.GetOrCreate(HttpMethod.Put, "api/v1/order", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Put, _baseClient.BaseAddress, "api/v1/order", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXOrder>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -105,7 +105,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Orders
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXOrder[]>> GetOrdersAsync(
+        public async Task<HttpResult<BitMEXOrder[]>> GetOrdersAsync(
             string? symbol = null,
             SymbolFilter? symbolFilter = null,
             Dictionary<string, object>? filter = null,
@@ -117,17 +117,17 @@ namespace BitMEX.Net.Clients.ExchangeApi
             int? limit = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             if (symbol != null)
-                parameters.AddOptional("symbol", symbol + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
-            parameters.AddOptional("filter", filter);
-            parameters.AddOptional("columns", columns);
-            parameters.AddOptional("start", offset);
-            parameters.AddOptional("count", limit);
-            parameters.AddBoolString("reverse", reverse ?? true);
-            parameters.AddOptional("startTime", startTime?.ToRfc3339String());
-            parameters.AddOptional("endTime", endTime?.ToRfc3339String());
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/order", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+                parameters.Add("symbol", symbol + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
+            parameters.AddRaw("filter", filter);
+            parameters.AddArray("columns", columns);
+            parameters.Add("start", offset);
+            parameters.Add("count", limit);
+            parameters.Add("reverse", reverse ?? true);
+            parameters.Add("startTime", startTime?.ToRfc3339String());
+            parameters.Add("endTime", endTime?.ToRfc3339String());
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/order", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXOrder[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -136,12 +136,12 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Order History By Day
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXExecution[]>> GetExecutionHistoryByDayAsync(string symbol, DateTime day, CancellationToken ct = default)
+        public async Task<HttpResult<BitMEXExecution[]>> GetExecutionHistoryByDayAsync(string symbol, DateTime day, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             parameters.Add("symbol", symbol ?? "all");
             parameters.Add("timestamp", day.ToString("yyyy-MM-ddT00:00:00.000Z"));
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/user/executionHistory", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/user/executionHistory", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXExecution[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -150,25 +150,25 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Cancel Order
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXOrder>> CancelOrderAsync(
+        public async Task<HttpResult<BitMEXOrder>> CancelOrderAsync(
             string? orderId = null,
             string? clientOrderId = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("orderID", orderId);
-            parameters.AddOptional("clOrdID", clientOrderId);
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
+            parameters.Add("orderID", orderId);
+            parameters.Add("clOrdID", clientOrderId);
             parameters.Add("text", LibraryHelpers.GetClientReference(() => _baseClient.ClientOptions.BrokerId, _baseClient.Exchange)); // Client reference
-            var request = _definitions.GetOrCreate(HttpMethod.Delete, "api/v1/order", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Delete, _baseClient.BaseAddress, "api/v1/order", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             var result = await _baseClient.SendAsync<BitMEXOrder[]>(request, parameters, ct).ConfigureAwait(false);
-            var orderResult = result.As<BitMEXOrder>(result.Data?.Single());
-            if (!orderResult)
-                return orderResult;
+            if (!result.Success)
+                return HttpResult.Fail<BitMEXOrder>(result);
 
-            if (!string.IsNullOrEmpty(orderResult.Data.Error))
-                return orderResult.AsError<BitMEXOrder>(new ServerError(new ErrorInfo(ErrorType.UnknownOrder, orderResult.Data.Error!)));
+            var order = result.Data.Single();
+            if (!string.IsNullOrEmpty(order.Error))
+                return HttpResult.Fail<BitMEXOrder>(result, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, order.Error!)));
 
-            return orderResult;
+            return HttpResult.Ok(result, order);
         }
 
         #endregion
@@ -176,16 +176,16 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Cancel Orders
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXOrder[]>> CancelOrdersAsync(
+        public async Task<HttpResult<BitMEXOrder[]>> CancelOrdersAsync(
             IEnumerable<string>? orderIds = null,
             IEnumerable<string>? clientOrderIds = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("orderID", orderIds == null ? null : string.Join(",", orderIds));
-            parameters.AddOptional("clOrdID", clientOrderIds == null ? null : string.Join(",", clientOrderIds));
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
+            parameters.Add("orderID", orderIds == null ? null : string.Join(",", orderIds));
+            parameters.Add("clOrdID", clientOrderIds == null ? null : string.Join(",", clientOrderIds));
             parameters.Add("text", LibraryHelpers.GetClientReference(() => _baseClient.ClientOptions.BrokerId, _baseClient.Exchange)); // Client reference
-            var request = _definitions.GetOrCreate(HttpMethod.Delete, "api/v1/order", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Delete, _baseClient.BaseAddress, "api/v1/order", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXOrder[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -194,18 +194,18 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Cancel All Orders
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXOrder[]>> CancelAllOrdersAsync(
+        public async Task<HttpResult<BitMEXOrder[]>> CancelAllOrdersAsync(
             IEnumerable<long>? targetAccountIds = null,
             string? symbol = null,
             Dictionary<string, object>? filter = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             parameters.Add("targetAccountIds", targetAccountIds == null ? "*" : string.Join(",", targetAccountIds));
-            parameters.AddOptional("symbol", symbol);
-            parameters.AddOptional("filter", filter);
+            parameters.Add("symbol", symbol);
+            parameters.AddRaw("filter", filter);
             parameters.Add("text", LibraryHelpers.GetClientReference(() => _baseClient.ClientOptions.BrokerId, _baseClient.Exchange)); // Client reference
-            var request = _definitions.GetOrCreate(HttpMethod.Delete, "api/v1/order/all", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Delete, _baseClient.BaseAddress, "api/v1/order/all", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXOrder[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -214,11 +214,11 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Cancel All Orders After
 
         /// <inheritdoc />
-        public async Task<WebCallResult> CancelAllAfterAsync(TimeSpan timeout, CancellationToken ct = default)
+        public async Task<HttpResult> CancelAllAfterAsync(TimeSpan timeout, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             parameters.Add("timeout", (int)timeout.TotalMilliseconds);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v1/order/cancelAllAfter", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v1/order/cancelAllAfter", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -227,7 +227,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get User Executions
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXExecution[]>> GetUserExecutionsAsync(
+        public async Task<HttpResult<BitMEXExecution[]>> GetUserExecutionsAsync(
             string? symbol = null,
             SymbolFilter? symbolFilter = null,
             Dictionary<string, object>? filter = null,
@@ -239,17 +239,17 @@ namespace BitMEX.Net.Clients.ExchangeApi
             int? limit = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             if (symbol != null)
-                parameters.AddOptional("symbol", symbol + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
-            parameters.AddOptional("filter", filter);
-            parameters.AddOptional("columns", columns);
-            parameters.AddOptional("count", limit);
-            parameters.AddOptional("start", offset);
-            parameters.AddOptionalBoolString("reverse", reverse);
-            parameters.AddOptional("startTime", startTime?.ToRfc3339String());
-            parameters.AddOptional("endTime", endTime?.ToRfc3339String());
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/execution", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+                parameters.Add("symbol", symbol + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
+            parameters.AddRaw("filter", filter);
+            parameters.AddArray("columns", columns);
+            parameters.Add("count", limit);
+            parameters.Add("start", offset);
+            parameters.Add("reverse", reverse);
+            parameters.Add("startTime", startTime?.ToRfc3339String());
+            parameters.Add("endTime", endTime?.ToRfc3339String());
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/execution", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXExecution[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -258,7 +258,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get User Trades
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXExecution[]>> GetUserTradesAsync(
+        public async Task<HttpResult<BitMEXExecution[]>> GetUserTradesAsync(
             IEnumerable<long>? targetAccountIds = null,
             string? symbol = null,
             SymbolFilter? symbolFilter = null,
@@ -271,18 +271,18 @@ namespace BitMEX.Net.Clients.ExchangeApi
             int? limit = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("targetAccountIds", targetAccountIds?.Any() != true ? "*": string.Join(",", targetAccountIds));
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
+            parameters.Add("targetAccountIds", targetAccountIds?.Any() != true ? "*": string.Join(",", targetAccountIds));
             if (symbol != null)
-                parameters.AddOptional("symbol", symbol + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
-            parameters.AddOptional("filter", filter);
-            parameters.AddOptional("columns", columns);
-            parameters.AddOptional("start", offset);
-            parameters.AddOptional("count", limit);
-            parameters.AddOptionalBoolString("reverse", reverse);
-            parameters.AddOptional("startTime", startTime?.ToRfc3339String());
-            parameters.AddOptional("endTime", endTime?.ToRfc3339String());
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/execution/tradeHistory", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+                parameters.Add("symbol", symbol + (symbolFilter == null ? "" : ":" + EnumConverter.GetString(symbolFilter)));
+            parameters.AddRaw("filter", filter);
+            parameters.AddArray("columns", columns);
+            parameters.Add("start", offset);
+            parameters.Add("count", limit);
+            parameters.Add("reverse", reverse);
+            parameters.Add("startTime", startTime?.ToRfc3339String());
+            parameters.Add("endTime", endTime?.ToRfc3339String());
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/execution/tradeHistory", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXExecution[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -291,17 +291,17 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Get Positions
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXPosition[]>> GetPositionsAsync(
+        public async Task<HttpResult<BitMEXPosition[]>> GetPositionsAsync(
             Dictionary<string, object>? filter = null,
             IEnumerable<string>? columns = null,
             int? limit = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("filter", filter);
-            parameters.AddOptional("columns", columns);
-            parameters.AddOptional("count", limit);            
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v1/position", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
+            parameters.AddRaw("filter", filter);
+            parameters.AddArray("columns", columns);
+            parameters.Add("count", limit);            
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/position", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXPosition[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -310,17 +310,17 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Set Cross Margin leverage
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXPosition>> SetCrossMarginLeverageAsync(
+        public async Task<HttpResult<BitMEXPosition>> SetCrossMarginLeverageAsync(
             string symbol,
             decimal leverage,
             long? targetAccountId = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             parameters.Add("symbol", symbol);
             parameters.Add("leverage", leverage);
-            parameters.AddOptional("targetAccountId", targetAccountId);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v1/position/crossLeverage", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            parameters.Add("targetAccountId", targetAccountId);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v1/position/crossLeverage", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXPosition>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -329,17 +329,17 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #region Set Isolated Margin leverage
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BitMEXPosition>> SetIsolatedMarginLeverageAsync(
+        public async Task<HttpResult<BitMEXPosition>> SetIsolatedMarginLeverageAsync(
             string symbol,
             decimal leverage,
             long? targetAccountId = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(BitMEXExchange._parameterSerializationSettings);
             parameters.Add("symbol", symbol);
             parameters.Add("leverage", leverage);
-            parameters.AddOptional("targetAccountId", targetAccountId);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v1/position/leverage", BitMEXExchange.RateLimiter.BitMEX, 1, true);
+            parameters.Add("targetAccountId", targetAccountId);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v1/position/leverage", BitMEXExchange.RateLimiter.BitMEX, 1, true);
             return await _baseClient.SendAsync<BitMEXPosition>(request, parameters, ct).ConfigureAwait(false);
         }
 

--- a/BitMEX.Net/Clients/ExchangeApi/BitMEXSocketClientExchangeApi.cs
+++ b/BitMEX.Net/Clients/ExchangeApi/BitMEXSocketClientExchangeApi.cs
@@ -44,14 +44,14 @@ namespace BitMEX.Net.Clients.ExchangeApi
         /// <summary>
         /// ctor
         /// </summary>
-        internal BitMEXSocketClientExchangeApi(ILogger logger, BitMEXSocketOptions options) :
-            base(logger, options.Environment.SocketClientAddress!, options, options.ExchangeOptions)
+        internal BitMEXSocketClientExchangeApi(ILoggerFactory? loggerFactory, BitMEXSocketOptions options) :
+            base(loggerFactory, BitMEXExchange.Metadata.Id, options.Environment.SocketClientAddress!, options, options.ExchangeOptions)
         {
             AddSystemSubscription(new BitMEXInfoSubscription(_logger));
 
             RegisterPeriodicQuery("Ping", TimeSpan.FromSeconds(5), x => new PingQuery(), (connection, result) =>
             {
-                if (!result)
+                if (!result.Success)
                 {
                     // Ping timeout, reconnect
                     _logger.LogWarning("[Sckt {SocketId}] Ping response timeout, reconnecting", connection.SocketId);
@@ -70,11 +70,11 @@ namespace BitMEX.Net.Clients.ExchangeApi
             => new BitMEXAuthenticationProvider(credentials);
 
         /// <inheritdoc />
-        public Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<BitMEXTradeUpdate[]>> onMessage, CancellationToken ct = default)
+        public Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<BitMEXTradeUpdate[]>> onMessage, CancellationToken ct = default)
             => SubscribeToTradeUpdatesAsync([symbol], onMessage, ct);
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<BitMEXTradeUpdate[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<BitMEXTradeUpdate[]>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DateTime, string?, SocketUpdate<BitMEXTradeUpdate[]>>((receiveTime, originalData, data) =>
             {
@@ -96,11 +96,11 @@ namespace BitMEX.Net.Clients.ExchangeApi
         }
 
         /// <inheritdoc />
-        public Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, BinPeriod period, Action<DataEvent<BitMEXAggTrade[]>> onMessage, CancellationToken ct = default)
+        public Task<WebSocketResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, BinPeriod period, Action<DataEvent<BitMEXAggTrade[]>> onMessage, CancellationToken ct = default)
             => SubscribeToKlineUpdatesAsync([symbol], period, onMessage, ct);
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(IEnumerable<string> symbols, BinPeriod period, Action<DataEvent<BitMEXAggTrade[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(IEnumerable<string> symbols, BinPeriod period, Action<DataEvent<BitMEXAggTrade[]>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DateTime, string?, SocketUpdate<BitMEXAggTrade[]>>((receiveTime, originalData, data) =>
             {
@@ -117,11 +117,11 @@ namespace BitMEX.Net.Clients.ExchangeApi
         }
 
         /// <inheritdoc />
-        public Task<CallResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(string symbol, Action<DataEvent<BitMEXBookTicker>> onMessage, CancellationToken ct = default)
+        public Task<WebSocketResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(string symbol, Action<DataEvent<BitMEXBookTicker>> onMessage, CancellationToken ct = default)
             => SubscribeToBookTickerUpdatesAsync([symbol], onMessage, ct);
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<BitMEXBookTicker>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<BitMEXBookTicker>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DateTime, string?, SocketUpdate<BitMEXBookTicker[]>>((receiveTime, originalData, data) =>
             {
@@ -143,11 +143,11 @@ namespace BitMEX.Net.Clients.ExchangeApi
         }
 
         /// <inheritdoc />
-        public Task<CallResult<UpdateSubscription>> SubscribeToAggregatedBookTickerUpdatesAsync(string symbol, BinPeriod period, Action<DataEvent<BitMEXBookTicker>> onMessage, CancellationToken ct = default)
+        public Task<WebSocketResult<UpdateSubscription>> SubscribeToAggregatedBookTickerUpdatesAsync(string symbol, BinPeriod period, Action<DataEvent<BitMEXBookTicker>> onMessage, CancellationToken ct = default)
             => SubscribeToAggregatedBookTickerUpdatesAsync([symbol], period, onMessage, ct);
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToAggregatedBookTickerUpdatesAsync(IEnumerable<string> symbols, BinPeriod period, Action<DataEvent<BitMEXBookTicker>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToAggregatedBookTickerUpdatesAsync(IEnumerable<string> symbols, BinPeriod period, Action<DataEvent<BitMEXBookTicker>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DateTime, string?, SocketUpdate<BitMEXBookTicker[]>>((receiveTime, originalData, data) =>
             {
@@ -169,7 +169,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToSettlementUpdatesAsync(Action<DataEvent<BitMEXSettlementHistory[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToSettlementUpdatesAsync(Action<DataEvent<BitMEXSettlementHistory[]>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DateTime, string?, SocketUpdate<BitMEXSettlementHistory[]>>((receiveTime, originalData, data) =>
             {
@@ -190,11 +190,11 @@ namespace BitMEX.Net.Clients.ExchangeApi
         }
 
         /// <inheritdoc />
-        public Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, Action<DataEvent<BitMEXOrderBookUpdate>> onMessage, CancellationToken ct = default)
+        public Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, Action<DataEvent<BitMEXOrderBookUpdate>> onMessage, CancellationToken ct = default)
             => SubscribeToOrderBookUpdatesAsync([symbol], onMessage, ct);
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<BitMEXOrderBookUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<BitMEXOrderBookUpdate>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DateTime, string?, SocketUpdate<BitMEXOrderBookUpdate[]>>((receiveTime, originalData, data) =>
             {
@@ -216,11 +216,11 @@ namespace BitMEX.Net.Clients.ExchangeApi
         }
 
         /// <inheritdoc />
-        public Task<CallResult<UpdateSubscription>> SubscribeToIncrementalOrderBookUpdatesAsync(string symbol, IncrementalBookLimit limit, Action<DataEvent<BitMEXOrderBookIncrementalUpdate>> onMessage, CancellationToken ct = default)
+        public Task<WebSocketResult<UpdateSubscription>> SubscribeToIncrementalOrderBookUpdatesAsync(string symbol, IncrementalBookLimit limit, Action<DataEvent<BitMEXOrderBookIncrementalUpdate>> onMessage, CancellationToken ct = default)
             => SubscribeToIncrementalOrderBookUpdatesAsync([symbol], limit, onMessage, ct);
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToIncrementalOrderBookUpdatesAsync(IEnumerable<string> symbols, IncrementalBookLimit limit, Action<DataEvent<BitMEXOrderBookIncrementalUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToIncrementalOrderBookUpdatesAsync(IEnumerable<string> symbols, IncrementalBookLimit limit, Action<DataEvent<BitMEXOrderBookIncrementalUpdate>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DateTime, string?, SocketUpdate<BitMEXOrderBookEntry[]>>((receiveTime, originalData, data) =>
             {
@@ -246,7 +246,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToLiquidationUpdatesAsync(Action<DataEvent<BitMEXLiquidation[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToLiquidationUpdatesAsync(Action<DataEvent<BitMEXLiquidation[]>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DateTime, string?, SocketUpdate<BitMEXLiquidation[]>>((receiveTime, originalData, data) =>
             {
@@ -263,7 +263,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToInsuranceUpdatesAsync(Action<DataEvent<BitMEXInsurance[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToInsuranceUpdatesAsync(Action<DataEvent<BitMEXInsurance[]>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DateTime, string?, SocketUpdate<BitMEXInsurance[]>>((receiveTime, originalData, data) =>
             {
@@ -284,7 +284,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(SymbolCategory? category, Action<DataEvent<BitMEXSymbolUpdate[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(SymbolCategory? category, Action<DataEvent<BitMEXSymbolUpdate[]>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DateTime, string?, SocketUpdate<BitMEXSymbolUpdate[]>>((receiveTime, originalData, data) =>
             {
@@ -304,7 +304,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(string symbol, Action<DataEvent<BitMEXSymbolUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(string symbol, Action<DataEvent<BitMEXSymbolUpdate>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DateTime, string?, SocketUpdate<BitMEXSymbolUpdate[]>>((receiveTime, originalData, data) =>
             {
@@ -325,7 +325,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<BitMEXSymbolUpdate[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<BitMEXSymbolUpdate[]>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DateTime, string?, SocketUpdate<BitMEXSymbolUpdate[]>>((receiveTime, originalData, data) =>
             {
@@ -346,11 +346,11 @@ namespace BitMEX.Net.Clients.ExchangeApi
         }
 
         /// <inheritdoc />
-        public Task<CallResult<UpdateSubscription>> SubscribeToFundingUpdatesAsync(string symbol, Action<DataEvent<BitMEXFundingRate>> onMessage, CancellationToken ct = default)
+        public Task<WebSocketResult<UpdateSubscription>> SubscribeToFundingUpdatesAsync(string symbol, Action<DataEvent<BitMEXFundingRate>> onMessage, CancellationToken ct = default)
             => SubscribeToFundingUpdatesAsync([symbol], onMessage, ct);
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToFundingUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<BitMEXFundingRate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToFundingUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<BitMEXFundingRate>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DateTime, string?, SocketUpdate<BitMEXFundingRate[]>>((receiveTime, originalData, data) =>
             {
@@ -374,7 +374,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToAnnouncementUpdatesAsync(Action<DataEvent<BitMEXAnnouncement[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToAnnouncementUpdatesAsync(Action<DataEvent<BitMEXAnnouncement[]>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DateTime, string?, SocketUpdate<BitMEXAnnouncement[]>>((receiveTime, originalData, data) =>
             {
@@ -394,7 +394,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToNotificationUpdatesAsync(Action<DataEvent<BitMEXNotification[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToNotificationUpdatesAsync(Action<DataEvent<BitMEXNotification[]>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DateTime, string?, SocketUpdate<BitMEXNotification[]>>((receiveTime, originalData, data) =>
             {
@@ -409,7 +409,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToBalanceUpdatesAsync(Action<DataEvent<BitMEXBalance[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToBalanceUpdatesAsync(Action<DataEvent<BitMEXBalance[]>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DateTime, string?, SocketUpdate<BitMEXBalance[]>>((receiveTime, originalData, data) =>
             {
@@ -429,7 +429,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToTransactionUpdatesAsync(Action<DataEvent<BitMEXTransaction[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToTransactionUpdatesAsync(Action<DataEvent<BitMEXTransaction[]>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DateTime, string?, SocketUpdate<BitMEXTransaction[]>>((receiveTime, originalData, data) =>
             {
@@ -450,7 +450,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToPositionUpdatesAsync(Action<DataEvent<BitMEXPosition[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToPositionUpdatesAsync(Action<DataEvent<BitMEXPosition[]>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DateTime, string?, SocketUpdate<BitMEXPosition[]>>((receiveTime, originalData, data) =>
             {
@@ -470,7 +470,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToMarginUpdatesAsync(Action<DataEvent<BitMEXMarginStatus>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToMarginUpdatesAsync(Action<DataEvent<BitMEXMarginStatus>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DateTime, string?, SocketUpdate<BitMEXMarginStatus[]>>((receiveTime, originalData, data) =>
             {
@@ -490,7 +490,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(Action<DataEvent<BitMEXOrder[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(Action<DataEvent<BitMEXOrder[]>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DateTime, string?, SocketUpdate<BitMEXOrder[]>>((receiveTime, originalData, data) =>
             {
@@ -510,7 +510,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(Action<DataEvent<BitMEXExecution[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(Action<DataEvent<BitMEXExecution[]>> onMessage, CancellationToken ct = default)
         {
             var handler = new Action<DateTime, string?, SocketUpdate<BitMEXExecution[]>>((receiveTime, originalData, data) =>
             {
@@ -532,9 +532,9 @@ namespace BitMEX.Net.Clients.ExchangeApi
         protected override Task<CallResult<string?>> GetConnectionUrlAsync(string address, bool authentication)
         {
             if (!authentication)
-                return Task.FromResult(new CallResult<string?>(address));
+                return Task.FromResult(CallResult<string?>.Ok(address));
 
-            return Task.FromResult(new CallResult<string?>(GetAddress()!));
+            return Task.FromResult(CallResult<string?>.Ok(GetAddress()!));
         }
 
         private string? GetAddress()

--- a/BitMEX.Net/Clients/ExchangeApi/BitMEXSocketClientExchangeApiShared.cs
+++ b/BitMEX.Net/Clients/ExchangeApi/BitMEXSocketClientExchangeApiShared.cs
@@ -18,8 +18,6 @@ namespace BitMEX.Net.Clients.ExchangeApi
         private const string _topicFuturesId = "BitMEXFutures";
         private const string _exchangeName = "BitMEX";
 
-        public string Exchange => _exchangeName;
-
         public TradingMode[] SupportedTradingModes => new[] { TradingMode.Spot, TradingMode.PerpetualLinear, TradingMode.DeliveryLinear, TradingMode.PerpetualInverse, TradingMode.DeliveryInverse };
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);

--- a/BitMEX.Net/Clients/ExchangeApi/BitMEXSocketClientExchangeApiShared.cs
+++ b/BitMEX.Net/Clients/ExchangeApi/BitMEXSocketClientExchangeApiShared.cs
@@ -16,26 +16,28 @@ namespace BitMEX.Net.Clients.ExchangeApi
     {
         private const string _topicSpotId = "BitMEXSpot";
         private const string _topicFuturesId = "BitMEXFutures";
+        private const string _exchangeName = "BitMEX";
 
-        public string Exchange => "BitMEX";
+        public string Exchange => _exchangeName;
 
         public TradingMode[] SupportedTradingModes => new[] { TradingMode.Spot, TradingMode.PerpetualLinear, TradingMode.DeliveryLinear, TradingMode.PerpetualInverse, TradingMode.DeliveryInverse };
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
 
         #region Spot Order client
 
-        EndpointOptions<SubscribeSpotOrderRequest> ISpotOrderSocketClient.SubscribeSpotOrderOptions { get; } = new EndpointOptions<SubscribeSpotOrderRequest>(false);
-        async Task<ExchangeResult<UpdateSubscription>> ISpotOrderSocketClient.SubscribeToSpotOrderUpdatesAsync(SubscribeSpotOrderRequest request, Action<DataEvent<SharedSpotOrder[]>> handler, CancellationToken ct)
+        SubscribeSpotOrderOptions ISpotOrderSocketClient.SubscribeSpotOrderOptions { get; } = new SubscribeSpotOrderOptions(_exchangeName, false);
+        async Task<WebSocketResult<UpdateSubscription>> ISpotOrderSocketClient.SubscribeToSpotOrderUpdatesAsync(SubscribeSpotOrderRequest request, Action<DataEvent<SharedSpotOrder[]>> handler, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderSocketClient)this).SubscribeSpotOrderOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeResult<UpdateSubscription>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, symbolInfoResult.Error!);
 
             var result = await SubscribeToOrderUpdatesAsync(
                 update => {
@@ -71,7 +73,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 },
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         private SharedTimeInForce? ParseTimeInForce(TimeInForce timeInForce)
@@ -102,16 +104,16 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #endregion
 
         #region Balance client
-        EndpointOptions<SubscribeBalancesRequest> IBalanceSocketClient.SubscribeBalanceOptions { get; } = new EndpointOptions<SubscribeBalancesRequest>(false);
-        async Task<ExchangeResult<UpdateSubscription>> IBalanceSocketClient.SubscribeToBalanceUpdatesAsync(SubscribeBalancesRequest request, Action<DataEvent<SharedBalance[]>> handler, CancellationToken ct)
+        SubscribeBalanceOptions IBalanceSocketClient.SubscribeBalanceOptions { get; } = new SubscribeBalanceOptions(_exchangeName, false);
+        async Task<WebSocketResult<UpdateSubscription>> IBalanceSocketClient.SubscribeToBalanceUpdatesAsync(SubscribeBalancesRequest request, Action<DataEvent<SharedBalance[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IBalanceSocketClient)this).SubscribeBalanceOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeBalanceOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeResult<UpdateSubscription>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, symbolInfoResult.Error!);
 
             var result = await SubscribeToBalanceUpdatesAsync(
                 update => handler(update.ToType<SharedBalance[]>(update.Data.Select(x => 
@@ -121,23 +123,23 @@ namespace BitMEX.Net.Clients.ExchangeApi
                     (x.Quantity + x.PendingCredit).ToSharedAssetQuantity(x.Currency) ?? 0)).ToArray())),
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         #endregion
 
         #region User Trade client
 
-        EndpointOptions<SubscribeUserTradeRequest> IUserTradeSocketClient.SubscribeUserTradeOptions { get; } = new EndpointOptions<SubscribeUserTradeRequest>(false);
-        async Task<ExchangeResult<UpdateSubscription>> IUserTradeSocketClient.SubscribeToUserTradeUpdatesAsync(SubscribeUserTradeRequest request, Action<DataEvent<SharedUserTrade[]>> handler, CancellationToken ct)
+        SubscribeUserTradeOptions IUserTradeSocketClient.SubscribeUserTradeOptions { get; } = new SubscribeUserTradeOptions(_exchangeName, false);
+        async Task<WebSocketResult<UpdateSubscription>> IUserTradeSocketClient.SubscribeToUserTradeUpdatesAsync(SubscribeUserTradeRequest request, Action<DataEvent<SharedUserTrade[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IUserTradeSocketClient)this).SubscribeUserTradeOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeUserTradeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeResult<UpdateSubscription>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, symbolInfoResult.Error!);
 
             var result = await SubscribeToUserTradeUpdatesAsync(
                 update =>
@@ -170,26 +172,26 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 },
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Book Ticker client
 
-        EndpointOptions<SubscribeBookTickerRequest> IBookTickerSocketClient.SubscribeBookTickerOptions { get; } = new EndpointOptions<SubscribeBookTickerRequest>(false)
+        SubscribeBookTickerOptions IBookTickerSocketClient.SubscribeBookTickerOptions { get; } = new SubscribeBookTickerOptions(_exchangeName, false)
         {
             SupportsMultipleSymbols = true,
             MaxSymbolCount = 20
         };
-        async Task<ExchangeResult<UpdateSubscription>> IBookTickerSocketClient.SubscribeToBookTickerUpdatesAsync(SubscribeBookTickerRequest request, Action<DataEvent<SharedBookTicker>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IBookTickerSocketClient.SubscribeToBookTickerUpdatesAsync(SubscribeBookTickerRequest request, Action<DataEvent<SharedBookTicker>> handler, CancellationToken ct)
         {
-            var validationError = ((IBookTickerSocketClient)this).SubscribeBookTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeBookTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeResult<UpdateSubscription>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, symbolInfoResult.Error!);
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)) : [request.Symbol!.GetSymbol(FormatSymbol)];
             var result = await SubscribeToBookTickerUpdatesAsync(symbols, update => handler(update.ToType(
@@ -202,26 +204,26 @@ namespace BitMEX.Net.Clients.ExchangeApi
                     request.TradingMode != TradingMode.Spot ? update.Data.BestBidQuantity : update.Data.BestBidQuantity.ToSharedSymbolQuantity(update.Data.Symbol) ?? 0
                     ))), ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         #endregion
 
         #region Order Book client
-        SubscribeOrderBookOptions IOrderBookSocketClient.SubscribeOrderBookOptions { get; } = new SubscribeOrderBookOptions(false, new[] { 10 })
+        SubscribeOrderBookOptions IOrderBookSocketClient.SubscribeOrderBookOptions { get; } = new SubscribeOrderBookOptions(_exchangeName, false, new[] { 10 })
         {
             MaxSymbolCount = 20,
             SupportsMultipleSymbols = true
         };
-        async Task<ExchangeResult<UpdateSubscription>> IOrderBookSocketClient.SubscribeToOrderBookUpdatesAsync(SubscribeOrderBookRequest request, Action<DataEvent<SharedOrderBook>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IOrderBookSocketClient.SubscribeToOrderBookUpdatesAsync(SubscribeOrderBookRequest request, Action<DataEvent<SharedOrderBook>> handler, CancellationToken ct)
         {
-            var validationError = ((IOrderBookSocketClient)this).SubscribeOrderBookOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeOrderBookOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeResult<UpdateSubscription>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, symbolInfoResult.Error!);
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)) : [request.Symbol!.GetSymbol(FormatSymbol)];
             var result = await SubscribeToOrderBookUpdatesAsync(symbols, update =>
@@ -238,21 +240,21 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 handler(update.ToType(book));
             }, ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Ticker client
-        SubscribeTickerOptions ITickerSocketClient.SubscribeTickerOptions { get; } = new SubscribeTickerOptions();
-        async Task<ExchangeResult<UpdateSubscription>> ITickerSocketClient.SubscribeToTickerUpdatesAsync(SubscribeTickerRequest request, Action<DataEvent<SharedSpotTicker>> handler, CancellationToken ct)
+        SubscribeTickerOptions ITickerSocketClient.SubscribeTickerOptions { get; } = new SubscribeTickerOptions(_exchangeName);
+        async Task<WebSocketResult<UpdateSubscription>> ITickerSocketClient.SubscribeToTickerUpdatesAsync(SubscribeTickerRequest request, Action<DataEvent<SharedSpotTicker>> handler, CancellationToken ct)
         {
-            var validationError = ((ITickerSocketClient)this).SubscribeTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeResult<UpdateSubscription>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, symbolInfoResult.Error!);
 
             SharedSpotTicker? ticker = null;
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
@@ -286,26 +288,26 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 handler(update.ToType(ticker));
             }, ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Trade client
 
-        EndpointOptions<SubscribeTradeRequest> ITradeSocketClient.SubscribeTradeOptions { get; } = new EndpointOptions<SubscribeTradeRequest>(false)
+        SubscribeTradeOptions ITradeSocketClient.SubscribeTradeOptions { get; } = new SubscribeTradeOptions(_exchangeName, false)
         {
             SupportsMultipleSymbols = true,
             MaxSymbolCount = 20
         };
-        async Task<ExchangeResult<UpdateSubscription>> ITradeSocketClient.SubscribeToTradeUpdatesAsync(SubscribeTradeRequest request, Action<DataEvent<SharedTrade[]>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> ITradeSocketClient.SubscribeToTradeUpdatesAsync(SubscribeTradeRequest request, Action<DataEvent<SharedTrade[]>> handler, CancellationToken ct)
         {
-            var validationError = ((ITradeSocketClient)this).SubscribeTradeOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeTradeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeResult<UpdateSubscription>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, symbolInfoResult.Error!);
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)) : [request.Symbol!.GetSymbol(FormatSymbol)];
             var result = await SubscribeToTradeUpdatesAsync(symbols, update =>
@@ -326,23 +328,23 @@ namespace BitMEX.Net.Clients.ExchangeApi
                     ).ToArray()));
                 }, ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         #endregion
 
         #region Futures Order client
 
-        EndpointOptions<SubscribeFuturesOrderRequest> IFuturesOrderSocketClient.SubscribeFuturesOrderOptions { get; } = new EndpointOptions<SubscribeFuturesOrderRequest>(false);
-        async Task<ExchangeResult<UpdateSubscription>> IFuturesOrderSocketClient.SubscribeToFuturesOrderUpdatesAsync(SubscribeFuturesOrderRequest request, Action<DataEvent<SharedFuturesOrder[]>> handler, CancellationToken ct)
+        SubscribeFuturesOrderOptions IFuturesOrderSocketClient.SubscribeFuturesOrderOptions { get; } = new SubscribeFuturesOrderOptions(_exchangeName, false);
+        async Task<WebSocketResult<UpdateSubscription>> IFuturesOrderSocketClient.SubscribeToFuturesOrderUpdatesAsync(SubscribeFuturesOrderRequest request, Action<DataEvent<SharedFuturesOrder[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderSocketClient)this).SubscribeFuturesOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeResult<UpdateSubscription>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, symbolInfoResult.Error!);
 
             var result = await SubscribeToOrderUpdatesAsync(
                 update => {
@@ -379,21 +381,21 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 },
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Position client
-        EndpointOptions<SubscribePositionRequest> IPositionSocketClient.SubscribePositionOptions { get; } = new EndpointOptions<SubscribePositionRequest>(false);
-        async Task<ExchangeResult<UpdateSubscription>> IPositionSocketClient.SubscribeToPositionUpdatesAsync(SubscribePositionRequest request, Action<DataEvent<SharedPosition[]>> handler, CancellationToken ct)
+        SubscribePositionOptions IPositionSocketClient.SubscribePositionOptions { get; } = new SubscribePositionOptions(_exchangeName, false);
+        async Task<WebSocketResult<UpdateSubscription>> IPositionSocketClient.SubscribeToPositionUpdatesAsync(SubscribePositionRequest request, Action<DataEvent<SharedPosition[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IPositionSocketClient)this).SubscribePositionOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribePositionOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbolInfoResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolInfoResult)
-                return new ExchangeResult<UpdateSubscription>(Exchange, symbolInfoResult.Error!);
+            if (!symbolInfoResult.Success)
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, symbolInfoResult.Error!);
 
             var result = await SubscribeToPositionUpdatesAsync(
                 update => handler(update.ToType<SharedPosition[]>(update.Data.Where(x => x.Currency != null).Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), x.Symbol, Math.Abs(x.CurrentQuantity ?? 0), x.Timestamp)
@@ -407,7 +409,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 }).ToArray())),
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         #endregion

--- a/BitMEX.Net/Clients/ExchangeApi/BitMEXSocketClientExchangeApiShared.cs
+++ b/BitMEX.Net/Clients/ExchangeApi/BitMEXSocketClientExchangeApiShared.cs
@@ -22,7 +22,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
-        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(BitMEXExchange.Metadata, this);
 
         #region Spot Order client
 
@@ -49,7 +49,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                     handler(update.ToType<SharedSpotOrder[]>(data.Select(x =>
                     
                         new SharedSpotOrder(
-                            ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol),
+                            ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, x.Symbol),
                             x.Symbol,
                             x.OrderId,
                             ParseOrderType(x.OrderType, x.ExecutionInstruction),
@@ -153,7 +153,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
 
                     handler(update.ToType<SharedUserTrade[]>(data.Select(x =>
                         new SharedUserTrade(
-                            ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol) ?? ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol),
+                            ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, x.Symbol) ?? ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, x.Symbol),
                             x.Symbol,
                             x.OrderId,
                             x.TradeId,
@@ -194,7 +194,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)) : [request.Symbol!.GetSymbol(FormatSymbol)];
             var result = await SubscribeToBookTickerUpdatesAsync(symbols, update => handler(update.ToType(
                 new SharedBookTicker(
-                    ExchangeSymbolCache.ParseSymbol(request.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, update.Data.Symbol),
+                    ExchangeSymbolCache.ParseSymbol(request.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, EnvironmentName, null, update.Data.Symbol),
                     update.Data.Symbol,
                     update.Data.BestAskPrice,
                     request.TradingMode != TradingMode.Spot ? update.Data.BestAskQuantity : update.Data.BestAskQuantity.ToSharedSymbolQuantity(update.Data.Symbol) ?? 0,
@@ -261,7 +261,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 if (ticker == null)
                 {
                     ticker = new SharedSpotTicker(
-                        ExchangeSymbolCache.ParseSymbol(request.Symbol.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, update.Data.Symbol),
+                        ExchangeSymbolCache.ParseSymbol(request.Symbol.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, EnvironmentName, null, update.Data.Symbol),
                         update.Data.Symbol,
                         update.Data.LastPrice,
                         update.Data.HighPrice,
@@ -315,7 +315,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
 
                 handler(update.ToType<SharedTrade[]>(update.Data.Select(x =>
                     new SharedTrade(
-                        ExchangeSymbolCache.ParseSymbol(request.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, x.Symbol),
+                        ExchangeSymbolCache.ParseSymbol(request.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, EnvironmentName, null, x.Symbol),
                         x.Symbol,
                         x.Quantity.ToSharedSymbolQuantity(x.Symbol) ?? 0,
                         x.Price,
@@ -355,7 +355,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
 
                     handler(update.ToType<SharedFuturesOrder[]>(data.Select(x =>
                         new SharedFuturesOrder(
-                            ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol),
+                            ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, x.Symbol),
                             x.Symbol,
                             x.OrderId,
                             ParseOrderType(x.OrderType, x.ExecutionInstruction),
@@ -396,7 +396,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, symbolInfoResult.Error!);
 
             var result = await SubscribeToPositionUpdatesAsync(
-                update => handler(update.ToType<SharedPosition[]>(update.Data.Where(x => x.Currency != null).Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), x.Symbol, Math.Abs(x.CurrentQuantity ?? 0), x.Timestamp)
+                update => handler(update.ToType<SharedPosition[]>(update.Data.Where(x => x.Currency != null).Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, x.Symbol), x.Symbol, Math.Abs(x.CurrentQuantity ?? 0), x.Timestamp)
                 {
                     AverageOpenPrice = x.AverageEntryPrice,
                     PositionMode = SharedPositionMode.OneWay,

--- a/BitMEX.Net/Clients/ExchangeApi/BitMEXSocketClientExchangeApiShared.cs
+++ b/BitMEX.Net/Clients/ExchangeApi/BitMEXSocketClientExchangeApiShared.cs
@@ -116,6 +116,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
             var result = await SubscribeToBalanceUpdatesAsync(
                 update => handler(update.ToType<SharedBalance[]>(update.Data.Select(x => 
                 new SharedBalance(
+                    SupportedTradingModes,
                     BitMEXExchange.AssetAliases.ExchangeToCommonName(BitMEXUtils.GetAssetFromCurrency(x.Currency) ?? x.Currency), 
                     x.Quantity.ToSharedAssetQuantity(x.Currency) ?? 0,
                     (x.Quantity + x.PendingCredit).ToSharedAssetQuantity(x.Currency) ?? 0)).ToArray())),

--- a/BitMEX.Net/Converters/BitMEXSourceGenerationContext.cs
+++ b/BitMEX.Net/Converters/BitMEXSourceGenerationContext.cs
@@ -1,5 +1,6 @@
 using BitMEX.Net.Objects.Internal;
 using BitMEX.Net.Objects.Models;
+using CryptoExchange.Net.Objects;
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
@@ -70,6 +71,8 @@ namespace BitMEX.Net.Converters
     [JsonSerializable(typeof(decimal))]
     [JsonSerializable(typeof(DateTime))]
     [JsonSerializable(typeof(DateTime?))]
+    [JsonSerializable(typeof(Parameters))]
+    [JsonSerializable(typeof(Parameters[]))]
     internal partial class BitMEXSourceGenerationContext : JsonSerializerContext
     {
     }

--- a/BitMEX.Net/Interfaces/Clients/ExchangeApi/IBitMEXRestClientExchangeApiAccount.cs
+++ b/BitMEX.Net/Interfaces/Clients/ExchangeApi/IBitMEXRestClientExchangeApiAccount.cs
@@ -25,7 +25,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="limit">["<c>count</c>"] Max number of results</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXUserEvent[]>> GetUserEventsAsync(long? fromId = null, int? limit = null, CancellationToken ct = default);
+        Task<HttpResult<BitMEXUserEvent[]>> GetUserEventsAsync(long? fromId = null, int? limit = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get account info
@@ -38,7 +38,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// </summary>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXAccountInfo>> GetAccountInfoAsync(CancellationToken ct = default);
+        Task<HttpResult<BitMEXAccountInfo>> GetAccountInfoAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get user trading fees
@@ -51,7 +51,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// </summary>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<Dictionary<string, BitMEXTradeFee>>> GetFeesAsync(CancellationToken ct = default);
+        Task<HttpResult<Dictionary<string, BitMEXTradeFee>>> GetFeesAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get deposit address
@@ -66,7 +66,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="network">["<c>network</c>"] Network</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<string>> GetDepositAddressAsync(string asset, string network, CancellationToken ct = default);
+        Task<HttpResult<string>> GetDepositAddressAsync(string asset, string network, CancellationToken ct = default);
 
         /// <summary>
         /// Get user margin status
@@ -80,7 +80,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="asset">["<c>currency</c>"] Filter by asset</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXMarginStatus[]>> GetMarginStatusAsync(string? asset = null, CancellationToken ct = default);
+        Task<HttpResult<BitMEXMarginStatus[]>> GetMarginStatusAsync(string? asset = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get user order quote fill ratio
@@ -94,7 +94,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="accountId">["<c>targetAccountId</c>"] Account id</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXFillRatio[]>> GetQuoteFillRatioAsync(long? accountId = null, CancellationToken ct = default);
+        Task<HttpResult<BitMEXFillRatio[]>> GetQuoteFillRatioAsync(long? accountId = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get user order quote value ratio
@@ -108,7 +108,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="accountId">["<c>targetAccountId</c>"] Account id</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXValueRatio[]>> GetQuoteValueRatioAsync(long accountId, CancellationToken ct = default);
+        Task<HttpResult<BitMEXValueRatio[]>> GetQuoteValueRatioAsync(long accountId, CancellationToken ct = default);
 
         /// <summary>
         /// Get user 30 days average USD trading volume
@@ -121,7 +121,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// </summary>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXUsdVolume[]>> GetTradingVolumeAsync(CancellationToken ct = default);
+        Task<HttpResult<BitMEXUsdVolume[]>> GetTradingVolumeAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get user balances
@@ -135,7 +135,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="asset">["<c>currency</c>"] Filter by asset</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXBalance[]>> GetBalancesAsync(string? asset = null, CancellationToken ct = default);
+        Task<HttpResult<BitMEXBalance[]>> GetBalancesAsync(string? asset = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get balance history
@@ -153,7 +153,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="limit">["<c>count</c>"] Max number of results</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXTransaction[]>> GetBalanceHistoryAsync(string? asset = null,
+        Task<HttpResult<BitMEXTransaction[]>> GetBalanceHistoryAsync(string? asset = null,
             long? targetAccountId = null,
             bool? reverse = null,
             int? offset = null,
@@ -173,7 +173,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="startTime">["<c>startTime</c>"] Filter by start time</param>
         /// <param name="endTime">["<c>endTime</c>"] Filter by end time</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<BitMEXBalanceSummary[]>> GetBalanceSummaryAsync(string? asset = null, DateTime? startTime = null, DateTime? endTime = null, CancellationToken ct = default);
+        Task<HttpResult<BitMEXBalanceSummary[]>> GetBalanceSummaryAsync(string? asset = null, DateTime? startTime = null, DateTime? endTime = null, CancellationToken ct = default);
 
         /// <summary>
         /// Transfer funds between accounts
@@ -189,7 +189,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="toAccountId">["<c>toAccountId</c>"] To account id</param>
         /// <param name="quantity">["<c>amount</c>"] Quantity</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<BitMEXTransaction>> TransferAsync(string asset, long fromAccountId, long toAccountId, long quantity, CancellationToken ct = default);
+        Task<HttpResult<BitMEXTransaction>> TransferAsync(string asset, long fromAccountId, long toAccountId, long quantity, CancellationToken ct = default);
 
         /// <summary>
         /// Create a new withdrawal request
@@ -212,7 +212,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="otpToken">["<c>otpToken</c>"] 2FA token. Required for all external withdrawals unless the destination is a saved address with skip2FA configured.</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXTransaction>> WithdrawAsync(
+        Task<HttpResult<BitMEXTransaction>> WithdrawAsync(
             string asset,
             string network,
             long quantity,
@@ -237,7 +237,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="transactId">["<c>transactID</c>"] Transaction id</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult> CancelWithdrawalAsync(string transactId, CancellationToken ct = default);
+        Task<HttpResult> CancelWithdrawalAsync(string transactId, CancellationToken ct = default);
 
         /// <summary>
         /// Set isolated margin enabled for a symbol
@@ -252,7 +252,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="isolatedMarginEnabled">["<c>enabled</c>"] Isolated margin enabled</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXPosition>> SetIsolatedMarginAsync(string symbol, bool isolatedMarginEnabled, CancellationToken ct = default);
+        Task<HttpResult<BitMEXPosition>> SetIsolatedMarginAsync(string symbol, bool isolatedMarginEnabled, CancellationToken ct = default);
 
         /// <summary>
         /// Update risk limit for a position
@@ -268,7 +268,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="targetAccountId">["<c>targetAccountId</c>"] Target account id</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXPosition>> SetRiskLimitAsync(string symbol, int riskLimit, long? targetAccountId = null, CancellationToken ct = default);
+        Task<HttpResult<BitMEXPosition>> SetRiskLimitAsync(string symbol, int riskLimit, long? targetAccountId = null, CancellationToken ct = default);
 
         /// <summary>
         /// Add or remove margin to an isolated margin position
@@ -284,7 +284,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="targetAccountId">["<c>targetAccountId</c>"] Target account id</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXPosition>> TransferMarginAsync(string symbol, long quantity, long? targetAccountId = null, CancellationToken ct = default);
+        Task<HttpResult<BitMEXPosition>> TransferMarginAsync(string symbol, long quantity, long? targetAccountId = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get saved addresses
@@ -297,7 +297,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// </summary>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXAddress[]>> GetSavedAddressesAsync(CancellationToken ct = default);
+        Task<HttpResult<BitMEXAddress[]>> GetSavedAddressesAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Add a saved address
@@ -319,7 +319,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="otpToken">["<c>otpToken</c>"] OTP token</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXAddress>> AddSavedAddressAsync(
+        Task<HttpResult<BitMEXAddress>> AddSavedAddressAsync(
             string currency,
             string network,
             string address,
@@ -342,7 +342,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// </summary>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXAddressBookConfig>> GetAddressBookSettingsAsync(CancellationToken ct = default);
+        Task<HttpResult<BitMEXAddressBookConfig>> GetAddressBookSettingsAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get API key info
@@ -355,6 +355,6 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// </summary>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXApiKey[]>> GetApiKeyInfoAsync(CancellationToken ct = default);
+        Task<HttpResult<BitMEXApiKey[]>> GetApiKeyInfoAsync(CancellationToken ct = default);
     }
 }

--- a/BitMEX.Net/Interfaces/Clients/ExchangeApi/IBitMEXRestClientExchangeApiExchangeData.cs
+++ b/BitMEX.Net/Interfaces/Clients/ExchangeApi/IBitMEXRestClientExchangeApiExchangeData.cs
@@ -18,7 +18,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// </summary>
         /// <param name="ct"></param>
         /// <returns></returns>
-        Task<WebCallResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default);
+        Task<HttpResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get active symbols
@@ -31,7 +31,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// </summary>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXSymbol[]>> GetActiveSymbolsAsync(CancellationToken ct = default);
+        Task<HttpResult<BitMEXSymbol[]>> GetActiveSymbolsAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get all symbols matching the filters
@@ -53,7 +53,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="limit">["<c>count</c>"] Max number of results</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXSymbol[]>> GetSymbolsAsync(
+        Task<HttpResult<BitMEXSymbol[]>> GetSymbolsAsync(
             string? symbol = null,
             SymbolFilter? symbolFilter = null,
             Dictionary<string, object>? filter = null,
@@ -76,7 +76,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// </summary>
         /// <param name="ct"></param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXIntervals>> GetActiveIntervalsAsync(CancellationToken ct = default);
+        Task<HttpResult<BitMEXIntervals>> GetActiveIntervalsAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get composite indexes
@@ -97,7 +97,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="limit">["<c>count</c>"] Max number of results</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXCompositeIndex[]>> GetCompositeIndexesAsync(
+        Task<HttpResult<BitMEXCompositeIndex[]>> GetCompositeIndexesAsync(
             string symbol,
             Dictionary<string, object>? filter = null,
             IEnumerable<string>? columns = null,
@@ -119,7 +119,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// </summary>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXIndex[]>> GetIndicesAsync(CancellationToken ct = default);
+        Task<HttpResult<BitMEXIndex[]>> GetIndicesAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get symbol USD volumes
@@ -132,7 +132,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// </summary>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXSymbolVolume[]>> GetSymbolVolumesAsync(CancellationToken ct = default);
+        Task<HttpResult<BitMEXSymbolVolume[]>> GetSymbolVolumesAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get public trades
@@ -154,7 +154,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="limit">["<c>count</c>"] Max number of results</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXTrade[]>> GetTradesAsync(
+        Task<HttpResult<BitMEXTrade[]>> GetTradesAsync(
             string symbol,
             SymbolFilter? symbolFilter = null,
             Dictionary<string, object>? filter = null,
@@ -188,7 +188,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="limit">["<c>count</c>"] Max number of results</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXAggTrade[]>> GetKlinesAsync(
+        Task<HttpResult<BitMEXAggTrade[]>> GetKlinesAsync(
             string symbol,
             BinPeriod period,
             SymbolFilter? symbolFilter = null,
@@ -213,7 +213,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// </summary>
         /// <param name="ct"></param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXExchangeStat[]>> GetExchangeStatsAsync(CancellationToken ct = default);
+        Task<HttpResult<BitMEXExchangeStat[]>> GetExchangeStatsAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get exchange stat history
@@ -226,7 +226,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// </summary>
         /// <param name="ct"></param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXExchangeStatHistory[]>> GetExchangeStatHistoryAsync(CancellationToken ct = default);
+        Task<HttpResult<BitMEXExchangeStatHistory[]>> GetExchangeStatHistoryAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get exchange USD stats
@@ -239,7 +239,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// </summary>
         /// <param name="ct"></param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXExchangeStatHistoryUsd[]>> GetExchangeStatHistoryUSDAsync(CancellationToken ct = default);
+        Task<HttpResult<BitMEXExchangeStatHistoryUsd[]>> GetExchangeStatHistoryUSDAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get settlement history
@@ -261,7 +261,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="limit">["<c>count</c>"] Max number of results</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXSettlementHistory[]>> GetSettlementHistoryAsync(
+        Task<HttpResult<BitMEXSettlementHistory[]>> GetSettlementHistoryAsync(
             string symbol,
             SymbolFilter? symbolFilter = null,
             Dictionary<string, object>? filter = null,
@@ -293,7 +293,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="limit">["<c>count</c>"] Max number of results</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXBookTicker[]>> GetBookTickerHistoryAsync(
+        Task<HttpResult<BitMEXBookTicker[]>> GetBookTickerHistoryAsync(
             string symbol,
             SymbolFilter? symbolFilter = null,
             Dictionary<string, object>? filter = null,
@@ -327,7 +327,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="limit">["<c>count</c>"] Max number of results</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXBookTicker[]>> GetAggregatedBookTickerHistoryAsync(
+        Task<HttpResult<BitMEXBookTicker[]>> GetAggregatedBookTickerHistoryAsync(
             string symbol,
             BinPeriod period,
             SymbolFilter? symbolFilter = null,
@@ -354,7 +354,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="limit">["<c>depth</c>"] Number of rows</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXOrderBook>> GetOrderBookAsync(string symbol, int limit, CancellationToken ct = default);
+        Task<HttpResult<BitMEXOrderBook>> GetOrderBookAsync(string symbol, int limit, CancellationToken ct = default);
 
         /// <summary>
         /// Get insurance history
@@ -376,7 +376,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="limit">["<c>count</c>"] Max number of results</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXInsurance[]>> GetInsuranceAsync(
+        Task<HttpResult<BitMEXInsurance[]>> GetInsuranceAsync(
             string asset,
             SymbolFilter? symbolFilter = null,
             Dictionary<string, object>? filter = null,
@@ -408,7 +408,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="limit">["<c>count</c>"] Max number of results</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXFundingRate[]>> GetFundingHistoryAsync(
+        Task<HttpResult<BitMEXFundingRate[]>> GetFundingHistoryAsync(
             string? symbol = null,
             SymbolFilter? symbolFilter = null,
             Dictionary<string, object>? filter = null,
@@ -432,7 +432,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="columns">["<c>columns</c>"]</param>
         /// <param name="ct"></param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXAnnouncement[]>> GetAnnouncementsAsync(
+        Task<HttpResult<BitMEXAnnouncement[]>> GetAnnouncementsAsync(
             IEnumerable<string>? columns = null,
             CancellationToken ct = default);
 
@@ -448,7 +448,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="columns">["<c>columns</c>"]</param>
         /// <param name="ct"></param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXAnnouncement[]>> GetUrgentAnnouncementsAsync(
+        Task<HttpResult<BitMEXAnnouncement[]>> GetUrgentAnnouncementsAsync(
             IEnumerable<string>? columns = null,
             CancellationToken ct = default);
 
@@ -463,7 +463,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// </summary>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXAsset[]>> GetAssetsAsync(CancellationToken ct = default);
+        Task<HttpResult<BitMEXAsset[]>> GetAssetsAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get asset networks
@@ -476,7 +476,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// </summary>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXNetwork[]>> GetAssetNetworksAsync(CancellationToken ct = default);
+        Task<HttpResult<BitMEXNetwork[]>> GetAssetNetworksAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get liquidations
@@ -492,7 +492,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="limit">["<c>count</c>"] Max number of results</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXLiquidation[]>> GetLiquidationsAsync(string? symbol = null,
+        Task<HttpResult<BitMEXLiquidation[]>> GetLiquidationsAsync(string? symbol = null,
             SymbolFilter? symbolFilter = null,
             Dictionary<string, object>? filter = null,
             IEnumerable<string>? columns = null,

--- a/BitMEX.Net/Interfaces/Clients/ExchangeApi/IBitMEXRestClientExchangeApiTrading.cs
+++ b/BitMEX.Net/Interfaces/Clients/ExchangeApi/IBitMEXRestClientExchangeApiTrading.cs
@@ -27,7 +27,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="day">["<c>timestamp</c>"] Day</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXExecution[]>> GetExecutionHistoryByDayAsync(string symbol, DateTime day, CancellationToken ct = default);
+        Task<HttpResult<BitMEXExecution[]>> GetExecutionHistoryByDayAsync(string symbol, DateTime day, CancellationToken ct = default);
 
         /// <summary>
         /// Place a new order
@@ -56,7 +56,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="clientOrderId">["<c>clOrdID</c>"] Client order id</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXOrder>> PlaceOrderAsync(
+        Task<HttpResult<BitMEXOrder>> PlaceOrderAsync(
             string symbol,
             OrderSide orderSide,
             OrderType orderType,
@@ -93,7 +93,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="limit">["<c>count</c>"] Max number of results</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXOrder[]>> GetOrdersAsync(
+        Task<HttpResult<BitMEXOrder[]>> GetOrdersAsync(
             string? symbol = null,
             SymbolFilter? symbolFilter = null,
             Dictionary<string, object>? filter = null,
@@ -124,7 +124,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="pegOffsetValue">["<c>pegOffsetValue</c>"] New peg offset value</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXOrder>> EditOrderAsync(
+        Task<HttpResult<BitMEXOrder>> EditOrderAsync(
             string? orderId = null,
             string? origClientOrderId = null,
             string? newClientOrderId = null,
@@ -148,7 +148,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="clientOrderId">["<c>clOrdID</c>"] Client order id. Either this or orderId should be provided</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXOrder>> CancelOrderAsync(
+        Task<HttpResult<BitMEXOrder>> CancelOrderAsync(
             string? orderId = null,
             string? clientOrderId = null,
             CancellationToken ct = default);
@@ -166,7 +166,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="clientOrderIds">["<c>clOrdID</c>"] Client order ids. Either this or orderIds should be provided</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXOrder[]>> CancelOrdersAsync(
+        Task<HttpResult<BitMEXOrder[]>> CancelOrdersAsync(
            IEnumerable<string>? orderIds = null,
            IEnumerable<string>? clientOrderIds = null,
            CancellationToken ct = default);
@@ -185,7 +185,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="filter">["<c>filter</c>"] Filter orders to cancel</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXOrder[]>> CancelAllOrdersAsync(
+        Task<HttpResult<BitMEXOrder[]>> CancelAllOrdersAsync(
             IEnumerable<long>? targetAccountIds = null,
             string? symbol = null,
             Dictionary<string, object>? filter = null,
@@ -203,7 +203,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="timeout">["<c>timeout</c>"] Timeout after which to cancel all orders. Use TimeSpan.Zero to cancel timeout</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult> CancelAllAfterAsync(TimeSpan timeout, CancellationToken ct = default);
+        Task<HttpResult> CancelAllAfterAsync(TimeSpan timeout, CancellationToken ct = default);
 
         /// <summary>
         /// Get raw user execution history
@@ -225,7 +225,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="limit">["<c>count</c>"] Max number of results</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXExecution[]>> GetUserExecutionsAsync(
+        Task<HttpResult<BitMEXExecution[]>> GetUserExecutionsAsync(
             string? symbol = null,
             SymbolFilter? symbolFilter = null,
             Dictionary<string, object>? filter = null,
@@ -258,7 +258,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="limit">["<c>count</c>"] Max number of results</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXExecution[]>> GetUserTradesAsync(
+        Task<HttpResult<BitMEXExecution[]>> GetUserTradesAsync(
             IEnumerable<long>? targetAccountIds = null,
             string? symbol = null,
             SymbolFilter? symbolFilter = null,
@@ -285,7 +285,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="limit">["<c>count</c>"] Max number of results</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXPosition[]>> GetPositionsAsync(
+        Task<HttpResult<BitMEXPosition[]>> GetPositionsAsync(
             Dictionary<string, object>? filter = null,
             IEnumerable<string>? columns = null,
             int? limit = null,
@@ -305,7 +305,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="targetAccountId">["<c>targetAccountId</c>"] Target account id</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXPosition>> SetCrossMarginLeverageAsync(
+        Task<HttpResult<BitMEXPosition>> SetCrossMarginLeverageAsync(
             string symbol,
             decimal leverage,
             long? targetAccountId = null,
@@ -325,7 +325,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="targetAccountId">["<c>targetAccountId</c>"] Target account id</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BitMEXPosition>> SetIsolatedMarginLeverageAsync(
+        Task<HttpResult<BitMEXPosition>> SetIsolatedMarginLeverageAsync(
             string symbol,
             decimal leverage,
             long? targetAccountId = null,

--- a/BitMEX.Net/Interfaces/Clients/ExchangeApi/IBitMEXSocketClientExchangeApi.cs
+++ b/BitMEX.Net/Interfaces/Clients/ExchangeApi/IBitMEXSocketClientExchangeApi.cs
@@ -29,7 +29,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<BitMEXTradeUpdate[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<BitMEXTradeUpdate[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to trade updates
@@ -44,7 +44,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<BitMEXTradeUpdate[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<BitMEXTradeUpdate[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to kline updates. Note that this subscription only pushes an update when the period is finished. Updates during a kline will not be pushed.
@@ -60,7 +60,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, BinPeriod period, Action<DataEvent<BitMEXAggTrade[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, BinPeriod period, Action<DataEvent<BitMEXAggTrade[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to kline updates
@@ -76,7 +76,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(IEnumerable<string> symbols, BinPeriod period, Action<DataEvent<BitMEXAggTrade[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(IEnumerable<string> symbols, BinPeriod period, Action<DataEvent<BitMEXAggTrade[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to book ticker updates
@@ -91,7 +91,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(string symbol, Action<DataEvent<BitMEXBookTicker>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(string symbol, Action<DataEvent<BitMEXBookTicker>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to book ticker updates
@@ -106,7 +106,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<BitMEXBookTicker>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<BitMEXBookTicker>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to aggregated book ticker updates
@@ -122,7 +122,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToAggregatedBookTickerUpdatesAsync(string symbol, BinPeriod period, Action<DataEvent<BitMEXBookTicker>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToAggregatedBookTickerUpdatesAsync(string symbol, BinPeriod period, Action<DataEvent<BitMEXBookTicker>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to aggregated book ticker updates
@@ -138,7 +138,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToAggregatedBookTickerUpdatesAsync(IEnumerable<string> symbols, BinPeriod period, Action<DataEvent<BitMEXBookTicker>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToAggregatedBookTickerUpdatesAsync(IEnumerable<string> symbols, BinPeriod period, Action<DataEvent<BitMEXBookTicker>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to settlement updates
@@ -152,7 +152,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToSettlementUpdatesAsync(Action<DataEvent<BitMEXSettlementHistory[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToSettlementUpdatesAsync(Action<DataEvent<BitMEXSettlementHistory[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to order book updated for the first 10 levels on each update
@@ -167,7 +167,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, Action<DataEvent<BitMEXOrderBookUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, Action<DataEvent<BitMEXOrderBookUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to order book updated for the first 10 levels on each update
@@ -182,7 +182,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<BitMEXOrderBookUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<BitMEXOrderBookUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to incremental order book updates
@@ -198,7 +198,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToIncrementalOrderBookUpdatesAsync(string symbol, IncrementalBookLimit limit, Action<DataEvent<BitMEXOrderBookIncrementalUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToIncrementalOrderBookUpdatesAsync(string symbol, IncrementalBookLimit limit, Action<DataEvent<BitMEXOrderBookIncrementalUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to incremental order book updates
@@ -214,7 +214,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToIncrementalOrderBookUpdatesAsync(IEnumerable<string> symbols, IncrementalBookLimit limit, Action<DataEvent<BitMEXOrderBookIncrementalUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToIncrementalOrderBookUpdatesAsync(IEnumerable<string> symbols, IncrementalBookLimit limit, Action<DataEvent<BitMEXOrderBookIncrementalUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to liquidation updates
@@ -228,7 +228,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToLiquidationUpdatesAsync(Action<DataEvent<BitMEXLiquidation[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToLiquidationUpdatesAsync(Action<DataEvent<BitMEXLiquidation[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to insurance updates
@@ -242,7 +242,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToInsuranceUpdatesAsync(Action<DataEvent<BitMEXInsurance[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToInsuranceUpdatesAsync(Action<DataEvent<BitMEXInsurance[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to symbol updates
@@ -257,7 +257,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(SymbolCategory? category, Action<DataEvent<BitMEXSymbolUpdate[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(SymbolCategory? category, Action<DataEvent<BitMEXSymbolUpdate[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to symbol updates. Note that only changed properties will be filled; unchanged properties will be null.
@@ -272,7 +272,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(string symbol, Action<DataEvent<BitMEXSymbolUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(string symbol, Action<DataEvent<BitMEXSymbolUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to symbol updates
@@ -287,7 +287,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<BitMEXSymbolUpdate[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<BitMEXSymbolUpdate[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to funding rate updates
@@ -302,7 +302,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToFundingUpdatesAsync(string symbol, Action<DataEvent<BitMEXFundingRate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToFundingUpdatesAsync(string symbol, Action<DataEvent<BitMEXFundingRate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to funding rate updates
@@ -317,7 +317,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToFundingUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<BitMEXFundingRate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToFundingUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<BitMEXFundingRate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to platform announcement updates
@@ -331,7 +331,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToAnnouncementUpdatesAsync(Action<DataEvent<BitMEXAnnouncement[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToAnnouncementUpdatesAsync(Action<DataEvent<BitMEXAnnouncement[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to public short lived notifications
@@ -345,7 +345,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToNotificationUpdatesAsync(Action<DataEvent<BitMEXNotification[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToNotificationUpdatesAsync(Action<DataEvent<BitMEXNotification[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user balance updates
@@ -359,7 +359,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToBalanceUpdatesAsync(Action<DataEvent<BitMEXBalance[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToBalanceUpdatesAsync(Action<DataEvent<BitMEXBalance[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user transaction (deposit/withdrawal) updates
@@ -373,7 +373,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToTransactionUpdatesAsync(Action<DataEvent<BitMEXTransaction[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToTransactionUpdatesAsync(Action<DataEvent<BitMEXTransaction[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user position updates
@@ -387,7 +387,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToPositionUpdatesAsync(Action<DataEvent<BitMEXPosition[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToPositionUpdatesAsync(Action<DataEvent<BitMEXPosition[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user margin updates
@@ -401,7 +401,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToMarginUpdatesAsync(Action<DataEvent<BitMEXMarginStatus>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToMarginUpdatesAsync(Action<DataEvent<BitMEXMarginStatus>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user order updates
@@ -415,7 +415,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(Action<DataEvent<BitMEXOrder[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(Action<DataEvent<BitMEXOrder[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user trade updates
@@ -429,7 +429,7 @@ namespace BitMEX.Net.Interfaces.Clients.ExchangeApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(Action<DataEvent<BitMEXExecution[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(Action<DataEvent<BitMEXExecution[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Get the shared socket requests client. This interface is shared with other exhanges to allow for a common implementation for different exchanges.

--- a/BitMEX.Net/Interfaces/Clients/IBitMEXUserClientProvider.cs
+++ b/BitMEX.Net/Interfaces/Clients/IBitMEXUserClientProvider.cs
@@ -22,6 +22,11 @@ namespace BitMEX.Net.Interfaces.Clients
         public void ClearUserClients(string userIdentifier);
 
         /// <summary>
+        /// Clear all client from the cache
+        /// </summary>
+        void Clear();
+
+        /// <summary>
         /// Get the Rest client for a specific user. In case the client does not exist yet it will be created and the <paramref name="credentials"/> should be provided, unless <see cref="InitializeUserClient" /> has been called prior for this user.
         /// </summary>
         /// <param name="userIdentifier">The identifier for user</param>

--- a/BitMEX.Net/Objects/Sockets/BitMEXQuery.cs
+++ b/BitMEX.Net/Objects/Sockets/BitMEXQuery.cs
@@ -18,7 +18,7 @@ namespace BitMEX.Net.Objects.Sockets
             _client = client;
             RequiredResponses = request.Parameters.Length;
 
-            MessageRouter = MessageRouter.CreateWithoutTopicFilter<T>(request.Parameters, HandleMessage);
+            MessageRouter = MessageRouter.CreateForQuery<T>(request.Parameters, HandleMessage);
         }
 
         public CallResult<T> HandleMessage(SocketConnection connection, DateTime receiveTime, string? originalData, T message)
@@ -27,15 +27,15 @@ namespace BitMEX.Net.Objects.Sockets
             {
                 if (resp.Error!.StartsWith("You are already subscribed to this topic"))
                     // Duplicate subscription, this is allowed by design
-                    return new CallResult<T>(message, originalData, null);
+                    return CallResult<T>.Ok(message, originalData);
 
                 if (resp.Status != null)
-                    return new CallResult<T>(new ServerError(resp.Status.Value, _client.GetErrorInfo(resp.Status.Value, resp.Error)), originalData);
+                    return CallResult<T>.Fail(new ServerError(resp.Status.Value, _client.GetErrorInfo(resp.Status.Value, resp.Error)), originalData);
 
-                return new CallResult<T>(new ServerError(ErrorInfo.Unknown with { Message = resp.Error }), originalData);
+                return CallResult<T>.Fail(new ServerError(ErrorInfo.Unknown with { Message = resp.Error }), originalData);
             }
 
-            return new CallResult<T>(message, originalData, null);
+            return CallResult<T>.Ok(message, originalData);
         }
     }
 }

--- a/BitMEX.Net/Objects/Sockets/PingQuery.cs
+++ b/BitMEX.Net/Objects/Sockets/PingQuery.cs
@@ -9,9 +9,7 @@ namespace BitMEX.Net.Objects.Sockets
         public PingQuery() : base("ping", false, 0)
         {
             RequestTimeout = TimeSpan.FromSeconds(5);
-
-            MessageRouter = MessageRouter.CreateWithoutHandler<string>("pong");
+            MessageRouter = MessageRouter.CreateVoid<string>("pong");
         }
-
     }
 }

--- a/BitMEX.Net/Objects/Sockets/Subscriptions/BitMEXInfoSubscription.cs
+++ b/BitMEX.Net/Objects/Sockets/Subscriptions/BitMEXInfoSubscription.cs
@@ -10,7 +10,7 @@ namespace BitMEX.Net.Objects.Sockets.Subscriptions
     {
         public BitMEXInfoSubscription(ILogger logger) : base(logger, false)
         {
-            MessageRouter = MessageRouter.CreateWithoutHandler<InfoUpdate>("info");
+            MessageRouter = MessageRouter.CreateVoid<InfoUpdate>("info");
         }
     }
 }

--- a/BitMEX.Net/Objects/Sockets/Subscriptions/BitMEXSubscription.cs
+++ b/BitMEX.Net/Objects/Sockets/Subscriptions/BitMEXSubscription.cs
@@ -29,7 +29,10 @@ namespace BitMEX.Net.Objects.Sockets.Subscriptions
 
             IndividualSubscriptionCount = symbols?.Length ?? 1;
 
-            MessageRouter = MessageRouter.CreateWithOptionalTopicFilters<SocketUpdate<T>>("upd" + topic, symbols, DoHandleMessage);
+            if (symbols != null)
+                MessageRouter = MessageRouter.CreateForEvent<SocketUpdate<T>>("upd" + topic, symbols, DoHandleMessage);
+            else
+                MessageRouter = MessageRouter.CreateForEvent<SocketUpdate<T>>("upd" + topic, DoHandleMessage);
         }
             
         /// <inheritdoc />
@@ -56,7 +59,7 @@ namespace BitMEX.Net.Objects.Sockets.Subscriptions
         public CallResult DoHandleMessage(SocketConnection connection, DateTime receiveTime, string? originalData, SocketUpdate<T> message)
         {
             _handler.Invoke(receiveTime, originalData, message);
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
     }
 }

--- a/BitMEX.Net/SymbolOrderBooks/BitMEXSymbolOrderBook.cs
+++ b/BitMEX.Net/SymbolOrderBooks/BitMEXSymbolOrderBook.cs
@@ -68,25 +68,25 @@ namespace BitMEX.Net.SymbolOrderBooks
         protected override async Task<CallResult<UpdateSubscription>> DoStartAsync(CancellationToken ct)
         {
             var symbolResult = await BitMEXUtils.UpdateSymbolInfoAsync(ct).ConfigureAwait(false);
-            if (!symbolResult)
-                return new CallResult<UpdateSubscription>(symbolResult.Error!);
+            if (!symbolResult.Success)
+                return CallResult<UpdateSubscription>.Fail(symbolResult.Error!);
 
             var result = await _socketClient.ExchangeApi.SubscribeToIncrementalOrderBookUpdatesAsync(Symbol, Levels == 25 ? Enums.IncrementalBookLimit.Top25 : Enums.IncrementalBookLimit.Full, DataHandler, ct).ConfigureAwait(false);
-            if (!result)
-                return result;
+            if (!result.Success)
+                return CallResult.Fail<UpdateSubscription>(result.Error);
 
             if (ct.IsCancellationRequested)
             {
                 await result.Data.CloseAsync().ConfigureAwait(false);
-                return result.AsError<UpdateSubscription>(new CancellationRequestedError());
+                return CallResult<UpdateSubscription>.Fail(new CancellationRequestedError());
             }
             Status = OrderBookStatus.Syncing;
 
             var setResult = await WaitForSetOrderBookAsync(_initialDataTimeout, ct).ConfigureAwait(false);
-            if (!setResult)
+            if (!setResult.Success)
                 await result.Data.CloseAsync().ConfigureAwait(false);
 
-            return setResult ? result : new CallResult<UpdateSubscription>(setResult.Error!);
+            return setResult.Success ? CallResult.Ok(result.Data) : CallResult.Fail<UpdateSubscription>(setResult.Error!);
         }
 
         private void DataHandler(DataEvent<BitMEXOrderBookIncrementalUpdate> @event)
@@ -118,7 +118,7 @@ namespace BitMEX.Net.SymbolOrderBooks
         }
 
         /// <inheritdoc />
-        protected override async Task<CallResult<bool>> DoResyncAsync(CancellationToken ct)
+        protected override async Task<CallResult> DoResyncAsync(CancellationToken ct)
         {
             return await WaitForSetOrderBookAsync(_initialDataTimeout, ct).ConfigureAwait(false);
         }

--- a/Examples/ai-friendly/03-websocket.cs
+++ b/Examples/ai-friendly/03-websocket.cs
@@ -13,6 +13,7 @@ var socketClient = new BitMEXSocketClient(options =>
     options.ApiCredentials = new BitMEXCredentials("API_KEY", "API_SECRET");
 });
 
+// Subscription methods return WebSocketResult<UpdateSubscription>.
 var tradeSubscription = await socketClient.ExchangeApi.SubscribeToTradeUpdatesAsync(
     "XBTUSD",
     update =>

--- a/Examples/ai-friendly/04-shared-client.cs
+++ b/Examples/ai-friendly/04-shared-client.cs
@@ -17,6 +17,12 @@ var shared = client.ExchangeApi.SharedClient;
 Console.WriteLine($"Exchange: {shared.Exchange}");
 Console.WriteLine($"Trading modes: {string.Join(", ", shared.SupportedTradingModes)}");
 
+var info = shared.Discover();
+var supportedFeatures = info.Features
+    .Where(x => x.Supported)
+    .Select(x => x.EndpointName);
+Console.WriteLine($"{info.Exchange} {info.TypeName}: {string.Join(", ", supportedFeatures)}");
+
 var assets = await shared.GetAssetsAsync(new GetAssetsRequest());
 if (!assets.Success)
 {

--- a/Examples/ai-friendly/05-error-handling.cs
+++ b/Examples/ai-friendly/05-error-handling.cs
@@ -1,6 +1,6 @@
 // 05-error-handling.cs
 //
-// Demonstrates: reusable BitMEX.Net REST and socket result handling.
+// Demonstrates: reusable BitMEX.Net REST, socket, and shared helper result handling.
 //
 // Setup: dotnet add package JKorf.BitMEX.Net
 
@@ -11,6 +11,10 @@ using CryptoExchange.Net.Objects.Sockets;
 
 var restClient = new BitMEXRestClient();
 var socketClient = new BitMEXSocketClient();
+
+// REST methods return HttpResult<T> or HttpResult.
+// WebSocket subscriptions return WebSocketResult<UpdateSubscription>.
+// Shared non-I/O symbol/cache helpers return ExchangeCallResult<T>.
 
 var book = await restClient.ExchangeApi.ExchangeData.GetOrderBookAsync("XBTUSD", 25);
 if (!EnsureSuccess(book, "load order book"))

--- a/Examples/ai-friendly/05-error-handling.cs
+++ b/Examples/ai-friendly/05-error-handling.cs
@@ -31,7 +31,7 @@ if (!EnsureSuccessSocket(subscription, "subscribe to incremental book"))
 
 await socketClient.UnsubscribeAsync(subscription.Data);
 
-static bool EnsureSuccess<T>(WebCallResult<T> result, string action)
+static bool EnsureSuccess<T>(HttpResult<T> result, string action)
 {
     if (result.Success)
         return true;
@@ -40,7 +40,7 @@ static bool EnsureSuccess<T>(WebCallResult<T> result, string action)
     return false;
 }
 
-static bool EnsureSuccessSocket<T>(CallResult<T> result, string action)
+static bool EnsureSuccessSocket<T>(WebSocketResult<T> result, string action)
 {
     if (result.Success)
         return true;

--- a/Examples/ai-friendly/README.md
+++ b/Examples/ai-friendly/README.md
@@ -8,9 +8,9 @@ These examples are intentionally small console programs that AI assistants can c
 | --- | --- |
 | `01-market-and-account.cs` | Public market data, balances, result handling, and BitMEX quantity conversion |
 | `02-trading-and-positions.cs` | Limit order placement, order query/cancel, positions, and leverage calls |
-| `03-websocket.cs` | Public and private websocket subscriptions |
-| `04-shared-client.cs` | CryptoExchange.Net shared client access from BitMEX.Net |
-| `05-error-handling.cs` | Reusable error handling helpers for REST and sockets |
+| `03-websocket.cs` | Public and private websocket subscriptions with teardown |
+| `04-shared-client.cs` | CryptoExchange.Net shared client access, capability discovery, and shared assets |
+| `05-error-handling.cs` | Reusable `HttpResult`, `WebSocketResult`, and `ExchangeCallResult` result handling notes |
 
 ## BitMEX Shape To Remember
 

--- a/docs/ai-api-map.md
+++ b/docs/ai-api-map.md
@@ -14,6 +14,7 @@ This map helps AI assistants route common user intents to the actual BitMEX.Net 
 | Websocket subscriptions | `socketClient.ExchangeApi` |
 | Shared REST abstraction | `restClient.ExchangeApi.SharedClient` |
 | Shared socket abstraction | `socketClient.ExchangeApi.SharedClient` |
+| Discover shared capabilities | `client.ExchangeApi.SharedClient.Discover()` |
 
 ## Market Data
 
@@ -90,6 +91,33 @@ This map helps AI assistants route common user intents to the actual BitMEX.Net 
 | Private orders | `SubscribeToOrderUpdatesAsync(...)` |
 | Private positions | `SubscribeToPositionUpdatesAsync(...)` |
 | Private executions | `SubscribeToUserTradeUpdatesAsync(...)` |
+
+## Shared APIs
+
+Use SharedApis for exchange-agnostic code across BitMEX.Net and other CryptoExchange.Net exchange libraries.
+
+| Intent | Pattern |
+| --- | --- |
+| Shared REST client | `new BitMEXRestClient().ExchangeApi.SharedClient` |
+| Shared socket client | `new BitMEXSocketClient().ExchangeApi.SharedClient` |
+| Discover shared capabilities | `client.ExchangeApi.SharedClient.Discover()` |
+| Shared assets | `IAssetsRestClient.GetAssetsAsync(new GetAssetsRequest())` |
+| Shared spot symbols | `ISpotSymbolRestClient.GetSpotSymbolsAsync(new GetSymbolsRequest())` |
+| Shared futures symbols | `IFuturesSymbolRestClient.GetFuturesSymbolsAsync(new GetSymbolsRequest())` |
+| Shared order book socket | `IOrderBookSocketClient.SubscribeToOrderBookUpdatesAsync(...)` |
+
+Shared REST calls return `HttpResult<T>` / `HttpResult`. Shared socket subscriptions return `WebSocketResult<UpdateSubscription>`. Shared non-I/O symbol/cache helpers such as symbol support checks return `ExchangeCallResult<T>`.
+
+For shared socket subscriptions, keep the concrete socket client and unsubscribe with `await socketClient.UnsubscribeAsync(subscription.Data)`.
+
+## Result Handling
+
+| Situation | Pattern |
+| --- | --- |
+| REST success check | `if (!result.Success) { Console.WriteLine(result.Error); return; }` |
+| Socket subscription success check | `WebSocketResult<UpdateSubscription> sub = await ...; if (!sub.Success) { Console.WriteLine(sub.Error); return; }` |
+| Read REST data | Read `result.Data` only after `result.Success` |
+| Shared helper data | Read `ExchangeCallResult<T>.Data` only after `result.Success` |
 
 ## Symbol And Quantity Cheatsheet
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -12,7 +12,7 @@ This file is optimized for AI coding assistants. It maps the actual BitMEX.Net A
 - Socket client: `BitMEXSocketClient`
 - Credentials: `BitMEXCredentials(string key, string secret)`
 
-BitMEX.Net is not organized by separate spot/futures client roots. All REST endpoints live under `ExchangeApi`, split into `ExchangeData`, `Account`, and `Trading`.
+BitMEX.Net is not organized by separate spot/futures client roots. All REST endpoints live under `ExchangeApi`, split into `ExchangeData`, `Account`, and `Trading`. REST methods return `HttpResult<T>` / `HttpResult`, WebSocket subscriptions return `WebSocketResult<UpdateSubscription>`, and shared symbol/cache helpers return `ExchangeCallResult<T>`.
 
 ## Correct Setup
 
@@ -273,6 +273,16 @@ BitMEX.Net implements CryptoExchange.Net shared APIs:
 - `socketClient.ExchangeApi.SharedClient`
 
 Supported trading modes include spot, linear/inverse perpetuals, and linear/inverse delivery contracts. Shared clients may call `BitMEXUtils.UpdateSymbolInfoAsync()` internally to map symbols and quantities.
+
+Use `SharedClient.Discover()` before routing optional shared features across exchanges:
+
+```csharp
+var info = restClient.ExchangeApi.SharedClient.Discover();
+var supported = info.Features.Where(x => x.Supported).Select(x => x.EndpointName);
+Console.WriteLine($"{info.Exchange} {info.TypeName}: {string.Join(", ", supported)}");
+```
+
+Shared REST calls return `HttpResult<T>` / `HttpResult`. Shared socket subscriptions return `WebSocketResult<UpdateSubscription>`. Shared non-I/O symbol/cache helpers, such as symbol support checks, return `ExchangeCallResult<T>`.
 
 ## Local State Helpers
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # BitMEX.Net
 
-BitMEX.Net is a CryptoExchange.Net-based .NET client for BitMEX REST and websocket APIs.
+BitMEX.Net is a CryptoExchange.Net-based .NET client for BitMEX REST and websocket APIs. REST methods return `HttpResult<T>` / `HttpResult`, WebSocket subscriptions return `WebSocketResult<UpdateSubscription>`, and shared symbol/cache helpers return `ExchangeCallResult<T>`.
 
 ## Install
 
@@ -29,11 +29,13 @@ REST:
 - `restClient.ExchangeApi.Account`
 - `restClient.ExchangeApi.Trading`
 - `restClient.ExchangeApi.SharedClient`
+- Call `restClient.ExchangeApi.SharedClient.Discover()` to inspect supported shared REST features
 
 Sockets:
 
 - `socketClient.ExchangeApi`
 - `socketClient.ExchangeApi.SharedClient`
+- Call `socketClient.ExchangeApi.SharedClient.Discover()` to inspect supported shared socket features
 
 There is no `SpotApi`, `UsdFuturesApi`, `FuturesApiV2`, `SpotApiV3`, `CoinFuturesApi`, or passphrase credential.
 


### PR DESCRIPTION
* Result types:
  * (Web)CallResult types are replaced by HttpResult, WebSocketResult and QueryResult with the same logic
  * WebSocketResult and QueryResult now return additional info for websocket operations
  * Updated result types to record type
  * Removed implicit result type conversion to bool, `if (result)` no longer works, instead use `if (result.Success)`
  * Fixed result object nullability hinting, for example Data might be null if Success isn't checked for true

* Clients:
  * Added ToString overrides on base API types
  * Added Exchange property on BaseApiClient
  * Added ApiCredentials property on Api clients
  * Updated ILogger source from client name to topic specific client name
  * Removed logging from client creation
  * Fixed issue in SocketApiClient.GetSocketConnection causing requests to always wait the full max 10 seconds when there was a reconnecting socket

* Shared APIs:
  * Added missing dedicated option types
  * Added Discover method on ISharedClient interface, returning info on supported capabilities and operations
  * Added ResetStaticExchangeParameters method on ExchangeParameters
  * Added Status property to SharedWithdrawal model
  * Added TradingModes property to SharedBalance model
  * Updated Shared ExchangeParameters parameter names to be case insensitive
  * Updated code comments
  * Replaced ExchangeResult with ExchangeCallResult type
  * Removed TradingMode from the response model, only maintained on models where it makes sense

* Added async streaming on UserDataTracker items with StreamUpdatesAsync
* Added cancellation token support to UserDataTracker starting
* Added SupportedEnvironments property to PlatformInfo
* Added Clear() method on UserClientProvider to clear all cached clients
* Added setter to BitMEXExchange.RateLimiter to allow custom rate limit settings
* Various small performance improvements
* Fixed websocket connection attempts counting towards rate limit even when server could not be reached