### PR TITLE
Shared asset types

### DIFF
--- a/BitMEX.Net/BitMEX.Net.csproj
+++ b/BitMEX.Net/BitMEX.Net.csproj
@@ -53,12 +53,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="CryptoExchange.Net" Version="12.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/BitMEX.Net/BitMEX.Net.csproj
+++ b/BitMEX.Net/BitMEX.Net.csproj
@@ -53,10 +53,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CryptoExchange.Net" Version="12.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiShared.cs
+++ b/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiShared.cs
@@ -27,9 +27,6 @@ namespace BitMEX.Net.Clients.ExchangeApi
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
         public SharedClientInfo Discover() => SharedUtils.GetClientInfo(BitMEXExchange.Metadata, this);
 
-        private static HashSet<string> _knownMetals = ["XAUT"];
-
-
         #region Asset client
         GetAssetsOptions IAssetsRestClient.GetAssetsOptions { get; } = new GetAssetsOptions(_exchangeName, true);
 
@@ -606,7 +603,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 QuoteAssetSubType = SharedAssetSubType.StableCoin
             };
 
-            if (_knownMetals.Contains(s.BaseAsset))
+            if (LibraryHelpers.IsCommodity(s.BaseAsset))
             {
                 result.BaseAssetType = SharedAssetType.TradFi;
                 result.BaseAssetSubType = SharedAssetSubType.Commodity;

--- a/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiShared.cs
+++ b/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiShared.cs
@@ -584,9 +584,6 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 .Where(x => x != null)
                 .ToArray();
 
-            var response = HttpResult.Ok(result, result.Data.Where(x => x.SymbolType == SymbolType.Spot).Select(s => 
-                ParseSpotSymbol(s)).ToArray());
-
             ExchangeSymbolCache.UpdateSymbolInfo(_topicSpotId, EnvironmentName, null, data);
             return HttpResult.Ok(result, SharedUtils.ApplySymbolFilter(data, request));
         }

--- a/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiShared.cs
+++ b/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiShared.cs
@@ -1221,7 +1221,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
             else if (s.Tags.Contains("eq"))
             {
                 result.BaseAssetType = SharedAssetType.TradFi;
-                result.BaseAssetSubType = SharedAssetSubType.Stock;
+                result.BaseAssetSubType = SharedAssetSubType.Equity;
             }
             else
             {

--- a/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiShared.cs
+++ b/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiShared.cs
@@ -560,7 +560,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #endregion
 
         #region Spot Symbol client
-        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicSpotId, EnvironmentName, null);
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicSpotId, EnvironmentName, null);
 
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
 
@@ -1161,7 +1161,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #endregion
 
         #region Futures Symbol client
-        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicFuturesId, EnvironmentName, null);
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicFuturesId, EnvironmentName, null);
 
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)

--- a/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiShared.cs
+++ b/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiShared.cs
@@ -1,16 +1,17 @@
+using BitMEX.Net.Enums;
+using BitMEX.Net.ExtensionMethods;
+using BitMEX.Net.Interfaces.Clients.ExchangeApi;
+using BitMEX.Net.Objects.Models;
+using CryptoExchange.Net;
+using CryptoExchange.Net.Objects;
+using CryptoExchange.Net.Objects.Errors;
 using CryptoExchange.Net.SharedApis;
 using System;
 using System.Collections.Generic;
-using BitMEX.Net.Interfaces.Clients.ExchangeApi;
-using System.Threading.Tasks;
-using System.Threading;
+using System.Diagnostics.Contracts;
 using System.Linq;
-using CryptoExchange.Net.Objects;
-using BitMEX.Net.ExtensionMethods;
-using BitMEX.Net.Enums;
-using CryptoExchange.Net;
-using BitMEX.Net.Objects.Models;
-using CryptoExchange.Net.Objects.Errors;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace BitMEX.Net.Clients.ExchangeApi
 {
@@ -25,6 +26,8 @@ namespace BitMEX.Net.Clients.ExchangeApi
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
         public SharedClientInfo Discover() => SharedUtils.GetClientInfo(BitMEXExchange.Metadata, this);
+
+        private static HashSet<string> _knownMetals = ["XAUT"];
 
 
         #region Asset client
@@ -560,6 +563,8 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #endregion
 
         #region Spot Symbol client
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicSpotId, EnvironmentName, null);
+
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
 
         async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
@@ -576,17 +581,42 @@ namespace BitMEX.Net.Clients.ExchangeApi
             if (!result.Success)
                 return HttpResult.Fail<SharedSpotSymbol[]>(result);
 
-            var response = HttpResult.Ok(result, result.Data.Where(x => x.SymbolType == SymbolType.Spot).Select(s => 
-                new SharedSpotSymbol(BitMEXExchange.AssetAliases.ExchangeToCommonName(s.BaseAsset), BitMEXExchange.AssetAliases.ExchangeToCommonName(s.QuoteAsset), s.Symbol, s.Status == SymbolStatus.Open)
-                {
-                    MinTradeQuantity = s.LotSize.ToSharedSymbolQuantity(s.Symbol),
-                    MaxTradeQuantity = s.MaxOrderQuantity.ToSharedSymbolQuantity(s.Symbol),
-                    QuantityStep = s.LotSize.ToSharedSymbolQuantity(s.Symbol),
-                    PriceStep = s.PriceStep
-                }).ToArray());
+            var data = result.Data
+                .Where(x => x.SymbolType == SymbolType.Spot)
+                .Select(x => ParseSpotSymbol(x)!)
+                .Where(x => x != null)
+                .ToArray();
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicSpotId, EnvironmentName, null, response.Data!);
-            return response;
+            var response = HttpResult.Ok(result, result.Data.Where(x => x.SymbolType == SymbolType.Spot).Select(s => 
+                ParseSpotSymbol(s)).ToArray());
+
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicSpotId, EnvironmentName, null, data);
+            return HttpResult.Ok(result, SharedUtils.ApplySymbolFilter(data, request));
+        }
+
+        private SharedSpotSymbol ParseSpotSymbol(BitMEXSymbol s)
+        {
+            var result = new SharedSpotSymbol(BitMEXExchange.AssetAliases.ExchangeToCommonName(s.BaseAsset), BitMEXExchange.AssetAliases.ExchangeToCommonName(s.QuoteAsset), s.Symbol, s.Status == SymbolStatus.Open)
+            {
+                MinTradeQuantity = s.LotSize.ToSharedSymbolQuantity(s.Symbol),
+                MaxTradeQuantity = s.MaxOrderQuantity.ToSharedSymbolQuantity(s.Symbol),
+                QuantityStep = s.LotSize.ToSharedSymbolQuantity(s.Symbol),
+                PriceStep = s.PriceStep,
+                QuoteAssetType = SharedAssetType.Crypto,
+                QuoteAssetSubType = SharedAssetSubType.StableCoin
+            };
+
+            if (_knownMetals.Contains(s.BaseAsset))
+            {
+                result.BaseAssetType = SharedAssetType.TradFi;
+                result.BaseAssetSubType = SharedAssetSubType.Commodity;
+            }
+            else
+            {
+                result.BaseAssetType = SharedAssetType.Crypto;
+            }
+
+            return result;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)
@@ -1133,6 +1163,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
         #endregion
 
         #region Futures Symbol client
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicFuturesId, EnvironmentName, null);
 
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
@@ -1151,15 +1182,19 @@ namespace BitMEX.Net.Clients.ExchangeApi
 
             // Quanto not supported as it doesn't currently fit in the response models
             var data = result.Data.Where(x => x.SymbolType != SymbolType.Spot && !x.IsQuanto);
-            if (request.TradingMode != null) 
-            {
-                data = data.Where(x => request.TradingMode.Value.IsPerpetual() ? x.SymbolType == SymbolType.PerpetualContract : x.SymbolType == SymbolType.Futures);
-                data = data.Where(x => request.TradingMode.Value.IsInverse() ? x.IsInverse : !x.IsInverse);
-            }
-            
-            var response = HttpResult.Ok(result, data.Select(s => new SharedFuturesSymbol(
-                    s.SymbolType == SymbolType.PerpetualContract ? 
-                            (s.IsInverse ? TradingMode.PerpetualInverse : TradingMode.PerpetualLinear): 
+            var symbols = data
+                .Select(x => ParseFuturesSymbol(x))
+                .ToArray();
+
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicFuturesId, EnvironmentName, null, symbols);
+            return HttpResult.Ok(result, SharedUtils.ApplySymbolFilter(symbols, request));
+        }
+
+        private SharedFuturesSymbol ParseFuturesSymbol(BitMEXSymbol s)
+        {
+            var result = new SharedFuturesSymbol(
+                    s.SymbolType == SymbolType.PerpetualContract ?
+                            (s.IsInverse ? TradingMode.PerpetualInverse : TradingMode.PerpetualLinear) :
                             (s.IsInverse ? TradingMode.DeliveryInverse : TradingMode.DeliveryLinear),
                     BitMEXExchange.AssetAliases.ExchangeToCommonName(s.BaseAsset),
                     BitMEXExchange.AssetAliases.ExchangeToCommonName(s.QuoteAsset),
@@ -1171,11 +1206,32 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 QuantityStep = s.LotSize,
                 PriceStep = s.PriceStep,
                 ContractSize = s.IsInverse ? (s.Multiplier / s.UnderlyingToSettleMultiplier) : (1 / s.UnderlyingToPositionMultiplier),
-                DeliveryTime = s.SettleTime
-            }).ToArray());
+                DeliveryTime = s.SettleTime,
+                QuoteAssetType = SharedAssetType.Crypto,
+                QuoteAssetSubType = SharedAssetSubType.StableCoin,
+                DisplayName = s.Symbol
+            };
+            
+            if (s.Tags.Contains("cm"))
+            {
+                result.BaseAssetType = SharedAssetType.TradFi;
+                result.BaseAssetSubType = SharedAssetSubType.Commodity;
+            }
+            else if (s.Tags.Contains("fx"))
+            {
+                result.BaseAssetType = SharedAssetType.Fiat;
+            }
+            else if (s.Tags.Contains("eq"))
+            {
+                result.BaseAssetType = SharedAssetType.TradFi;
+                result.BaseAssetSubType = SharedAssetSubType.Stock;
+            }
+            else
+            {
+                result.BaseAssetType = SharedAssetType.Crypto;
+            }
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicFuturesId, EnvironmentName, null, response.Data!);
-            return response;
+            return result;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)

--- a/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiShared.cs
+++ b/BitMEX.Net/Clients/ExchangeApi/BitMEXRestClientExchangeApiShared.cs
@@ -599,6 +599,7 @@ namespace BitMEX.Net.Clients.ExchangeApi
                 MaxTradeQuantity = s.MaxOrderQuantity.ToSharedSymbolQuantity(s.Symbol),
                 QuantityStep = s.LotSize.ToSharedSymbolQuantity(s.Symbol),
                 PriceStep = s.PriceStep,
+                DisplayName = s.Symbol,
                 QuoteAssetType = SharedAssetType.Crypto,
                 QuoteAssetSubType = SharedAssetSubType.StableCoin
             };


### PR DESCRIPTION
Updated CryptoExchange.Net to v12.2.0 
Added SpotSymbolCatalog to Shared ISpotSymbolRestClient interface
Added FuturesSymbolCatalog to Shared IFuturesSymbolRestClient interface
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to GetSymbolsRequest model
Added DisplayName to SharedSpotSymbol and SharedFuturesSymbol models
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to SharedSpotSymbol and SharedFuturesSymbol models
Added DebuggerDisplay attributes to Shared models
